### PR TITLE
fix: S3 FileKey 파싱 오류 수정 & CrewService 이전기수 하드코딩 현재 구조로 수정

### DIFF
--- a/src/main/java/sopt/org/homepage/aboutsopt/service/AboutSoptService.java
+++ b/src/main/java/sopt/org/homepage/aboutsopt/service/AboutSoptService.java
@@ -17,5 +17,5 @@ public interface AboutSoptService {
      * @param generation 조회할 기수
      * @return 해당 기수의 스터디 수
      */
-    Integer getStudyCount(Integer generation);
+    Integer getStudyCount(Integer generation, boolean isActive);
 }

--- a/src/main/java/sopt/org/homepage/aboutsopt/service/AboutSoptServiceImpl.java
+++ b/src/main/java/sopt/org/homepage/aboutsopt/service/AboutSoptServiceImpl.java
@@ -41,7 +41,7 @@ public class AboutSoptServiceImpl implements AboutSoptService {
 
         var members = playgroundService.getAllMembers(targetGeneration);
         var projects = projectService.findByGeneration(targetGeneration);
-        var studyCount = crewService.getStudyCount(targetGeneration);
+        var studyCount = crewService.getStudyCount(targetGeneration, targetGeneration == currentGeneration);
 
         return GetAboutSoptResponseDto.builder()
                 .aboutSopt(convertToAboutSoptDto(aboutSopt))
@@ -54,8 +54,8 @@ public class AboutSoptServiceImpl implements AboutSoptService {
     }
 
     @Override
-    public Integer getStudyCount(Integer generation) {
-        return crewService.getStudyCount(generation);
+    public Integer getStudyCount(Integer generation, boolean isActive) {
+        return crewService.getStudyCount(generation, isActive);
     }
 
     private int determineTargetGeneration(int currentGeneration) {

--- a/src/main/java/sopt/org/homepage/internal/crew/CrewService.java
+++ b/src/main/java/sopt/org/homepage/internal/crew/CrewService.java
@@ -21,25 +21,19 @@ public class CrewService {
     private final ResponseMapper responseMapper;
     private final AuthConfig authConfig;
     private final String studyCategory = URLEncoder.encode("스터디", StandardCharsets.UTF_8);
-    private final Integer PREV_GEN = 33;
 
-    public List<StudyResponse> getAllStudy(Integer generation){
+    public List<StudyResponse> getAllStudy(Integer generation, boolean isActive){
         val MAX_TAKE_COUNT = 50;
-        val activeGen = (generation != null) ? generation : PREV_GEN;
-        val active = !activeGen.equals(PREV_GEN);
 
-        val crewApiResponse = crewClient.getAllStudy(1, MAX_TAKE_COUNT, activeGen, active, studyCategory);
+        val crewApiResponse = crewClient.getAllStudy(1, MAX_TAKE_COUNT, generation, isActive, studyCategory);
 
 //        val crewApiResponse = crewClient.getAllStudy(authConfig.getCrewApiToken(),1, MAX_TAKE_COUNT, activeGen, active, studyCategory);
 
         return crewApiResponse.data().meetings().stream().map(responseMapper::toStudyResponse).toList();
     }
 
-    public Integer getStudyCount(Integer generation) {
-        val activeGen = (generation != null) ? generation : PREV_GEN;
-        val active = !activeGen.equals(PREV_GEN);
-
-        val crewApiResponse = crewClient.getAllStudy(1, 1, activeGen, active, studyCategory);
+    public Integer getStudyCount(Integer generation, boolean isActive) {
+        val crewApiResponse = crewClient.getAllStudy(1, 1, generation, isActive, studyCategory);
 
         return crewApiResponse.data().meta().itemCount();
 //        try {

--- a/src/main/java/sopt/org/homepage/main/service/MainServiceImpl.java
+++ b/src/main/java/sopt/org/homepage/main/service/MainServiceImpl.java
@@ -474,7 +474,7 @@ public class MainServiceImpl implements MainService {
         int targetGeneration = determineTargetGeneration(generation);
         var memberStats = getMemberStatistics(targetGeneration);
         var projectCount = getProjectCount(targetGeneration);
-        var studyCount = getStudyCount(targetGeneration);
+        var studyCount = getStudyCount(targetGeneration, targetGeneration == generation);
 
         return new GetAboutSoptResponseDto.ActivitiesRecords(
                 memberStats,
@@ -522,8 +522,8 @@ public class MainServiceImpl implements MainService {
     }
 
 
-    private Integer getStudyCount(Integer generation) {
-        return crewService.getStudyCount(generation);
+    private Integer getStudyCount(Integer generation, boolean isActive) {
+        return crewService.getStudyCount(generation, isActive);
     }
 
 


### PR DESCRIPTION
### 관련 이슈가 있다면 적어주세요.
* 어드민 배포 시, S3 이미지 링크 잘못 업로드 되는 이슈 수정
* 크루API 활용 시, 33기로 하드코딩 되어있던 이전기수 정보 → 현재 이전기수 회귀식으로 적용되도록 수정
## 📌 개발 이유

## 💻 수정 사항
* 어드민 배포 시, S3 이미지 링크 잘못 업로드 되는 이슈 
→ S3 파일키가 잘못 파싱되어서 발생 ⇒ 수정완료
* 크루API 활용 시, 33기로 하드코딩 되어있던 이전기수 정보 
→ 현재 이전기수 회귀식으로 적용되도록 수정

## 🧪 테스트 방법
* /v2/api-docs

## ⛳️ 고민한 점 || 궁굼한 점

## 🎯 리뷰 포인트

## 📁 레퍼런스
