### PR TITLE
[FEAT] 솝티클 및 활동후기 추가 가능 플레이그라운드 연동

### DIFF
--- a/src/main/java/sopt/org/homepage/common/mapper/ResponseMapper.java
+++ b/src/main/java/sopt/org/homepage/common/mapper/ResponseMapper.java
@@ -88,6 +88,20 @@ public class ResponseMapper {
     }
 
     public ReviewsResponseDto toReviewResponseDto(ReviewEntity entity) {
+        // subject List<String>을 단일 String으로 변환
+        String subjectStr;
+        List<String> subjects = entity.getSubject();
+        
+        if (subjects == null || subjects.isEmpty()) {
+            subjectStr = "";
+        } else if (subjects.size() == 1) {
+            // 배열 길이가 1이면 그 값만 사용
+            subjectStr = subjects.get(0);
+        } else {
+            // 배열 길이가 2 이상이면 " | "로 구분하여 하나의 문자열로 결합
+            subjectStr = String.join(" | ", subjects);
+        }
+        
         return ReviewsResponseDto.builder()
                 .id(entity.getId())
                 .title(entity.getTitle())
@@ -96,7 +110,7 @@ public class ResponseMapper {
                 .generation(entity.getGeneration())
                 .description(entity.getDescription())
                 .part(entity.getPart())
-                .subject(entity.getSubject())
+                .subject(subjectStr)
                 .thumbnailUrl(entity.getThumbnailUrl())
                 .platform(entity.getPlatform())
                 .url(entity.getUrl())

--- a/src/main/java/sopt/org/homepage/exception/GlobalExceptionHandler.java
+++ b/src/main/java/sopt/org/homepage/exception/GlobalExceptionHandler.java
@@ -1,87 +1,108 @@
 package sopt.org.homepage.exception;
 
-import feign.FeignException;
-import jakarta.persistence.EntityNotFoundException;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.server.ResponseStatusException;
 
+import feign.FeignException;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-    @ExceptionHandler(BusinessLogicException.class)
-    public ResponseEntity<String> businessLogicException (BusinessLogicException ex) {
-        log.error(ex.getMessage());
-        return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ex.getMessage());
-    }
+	@ExceptionHandler(BusinessLogicException.class)
+	public ResponseEntity<String> businessLogicException(BusinessLogicException ex) {
+		log.error(ex.getMessage());
+		return ResponseEntity
+			.status(HttpStatus.INTERNAL_SERVER_ERROR)
+			.body(ex.getMessage());
+	}
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<String> methodArgumentNotValidException (MethodArgumentNotValidException ex) {
-        log.error(ex.getMessage());
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(ex.getMessage());
-    }
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<String> methodArgumentNotValidException(MethodArgumentNotValidException ex) {
+		log.error(ex.getMessage());
+		return ResponseEntity
+			.status(HttpStatus.BAD_REQUEST)
+			.body(ex.getMessage());
+	}
 
-    @ExceptionHandler(EntityNotFoundException.class)
-    public ResponseEntity<String> entityNotfoundException (EntityNotFoundException ex) {
-        log.error(ex.getMessage());
-        return ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
-                .body(ex.getMessage());
-    }
+	@ExceptionHandler(EntityNotFoundException.class)
+	public ResponseEntity<String> entityNotfoundException(EntityNotFoundException ex) {
+		log.error(ex.getMessage());
+		return ResponseEntity
+			.status(HttpStatus.NOT_FOUND)
+			.body(ex.getMessage());
+	}
 
-    @ExceptionHandler(ClientBadRequestException.class)
-    public ResponseEntity<String> clientBadRequestException (ClientBadRequestException ex) {
-        log.error(ex.getMessage());
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(ex.getMessage());
-    }
+	@ExceptionHandler(ClientBadRequestException.class)
+	public ResponseEntity<String> clientBadRequestException(ClientBadRequestException ex) {
+		log.error(ex.getMessage());
+		return ResponseEntity
+			.status(HttpStatus.BAD_REQUEST)
+			.body(ex.getMessage());
+	}
 
-    @ExceptionHandler(ForbiddenClientException.class)
-    public ResponseEntity<String> forbiddenClientException (ForbiddenClientException ex) {
-        log.error(ex.getMessage());
-        return ResponseEntity
-                .status(HttpStatus.FORBIDDEN)
-                .body(ex.getMessage());
-    }
+	@ExceptionHandler(ForbiddenClientException.class)
+	public ResponseEntity<String> forbiddenClientException(ForbiddenClientException ex) {
+		log.error(ex.getMessage());
+		return ResponseEntity
+			.status(HttpStatus.FORBIDDEN)
+			.body(ex.getMessage());
+	}
 
+	@ExceptionHandler(FeignException.class)
+	public ResponseEntity<String> feignClientException(FeignException ex) {
+		return ResponseEntity
+			.status(HttpStatus.UNAUTHORIZED)
+			.body(ex.getMessage());
+	}
 
-    @ExceptionHandler(FeignException.class)
-    public ResponseEntity<String> feignClientException(FeignException ex) {
-        return ResponseEntity
-                .status(HttpStatus.UNAUTHORIZED)
-                .body(ex.getMessage());
-    }
+	@ExceptionHandler(TokenException.class)
+	public ResponseEntity<String> tokenException(TokenException ex) {
+		return ResponseEntity
+			.status(HttpStatus.INTERNAL_SERVER_ERROR)
+			.body(ex.getMessage());
+	}
 
-    @ExceptionHandler(TokenException.class)
-    public ResponseEntity<String> tokenException(TokenException ex) {
-        return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ex.getMessage());
-    }
+	@ExceptionHandler(RuntimeException.class)
+	public ResponseEntity<String> unknownException(RuntimeException ex) {
+		log.error("[Unknown Error] : " + ex.getMessage());
+		ex.printStackTrace();
+		return ResponseEntity
+			.status(HttpStatus.INTERNAL_SERVER_ERROR)
+			.body(ex.getMessage());
+	}
 
-    @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<String> unknownException (RuntimeException ex) {
-        log.error("[Unknown Error] : " + ex.getMessage());
-        ex.printStackTrace();
-        return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ex.getMessage());
-    }
+	@ExceptionHandler(ResponseStatusException.class)
+	public ResponseEntity<String> handleResponseStatusException(ResponseStatusException ex) {
+		log.error(ex.getMessage());
+		return ResponseEntity
+			.status(ex.getStatusCode())
+			.body(ex.getReason() != null ? ex.getReason() : "Unknown error occurred");
+	}
 
-    @ExceptionHandler(ResponseStatusException.class)
-    public ResponseEntity<String> handleResponseStatusException(ResponseStatusException ex) {
-        log.error(ex.getMessage());
-        return ResponseEntity
-                .status(ex.getStatusCode())
-                .body(ex.getReason() != null ? ex.getReason() : "Unknown error occurred");
-    }
+	@ExceptionHandler({HttpMessageNotReadableException.class})
+	public ResponseEntity<String> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
+		if (ex.getMessage() != null && ex.getMessage().contains("ClientBadRequestException")) {
+			String errorMessage = ex.getMessage();
+
+			int start =
+				errorMessage.indexOf("[ClientBadRequestException] : ") + "[ClientBadRequestException] : ".length();
+			int end = errorMessage.length();
+			String clientErrorMessage = errorMessage.substring(start, end);
+
+			return ResponseEntity
+				.status(HttpStatus.BAD_REQUEST)
+				.body(clientErrorMessage);
+		}
+
+		return ResponseEntity
+			.status(HttpStatus.BAD_REQUEST)
+			.body("Invalid request format: " + ex.getMessage());
+	}
 }

--- a/src/main/java/sopt/org/homepage/review/dto/request/AddReviewMainCategory.java
+++ b/src/main/java/sopt/org/homepage/review/dto/request/AddReviewMainCategory.java
@@ -1,0 +1,30 @@
+package sopt.org.homepage.review.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum AddReviewMainCategory {
+	ACTIVITY("전체 활동"),
+	RECRUITING("서류/면접");
+
+	private final String value;
+
+	AddReviewMainCategory(String value) {
+		this.value = value;
+	}
+
+	@JsonValue
+	public String getValue() {
+		return value;
+	}
+
+	@JsonCreator
+	public static AddReviewMainCategory from(String value) {
+		for (AddReviewMainCategory category : AddReviewMainCategory.values()) {
+			if (category.getValue().equals(value)) {
+				return category;
+			}
+		}
+		throw new IllegalArgumentException("Unknown Main Category value: " + value);
+	}
+}

--- a/src/main/java/sopt/org/homepage/review/dto/request/AddReviewMainCategory.java
+++ b/src/main/java/sopt/org/homepage/review/dto/request/AddReviewMainCategory.java
@@ -3,6 +3,8 @@ package sopt.org.homepage.review.dto.request;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import sopt.org.homepage.exception.ClientBadRequestException;
+
 public enum AddReviewMainCategory {
 	ACTIVITY("전체 활동"),
 	RECRUITING("서류/면접");
@@ -25,6 +27,14 @@ public enum AddReviewMainCategory {
 				return category;
 			}
 		}
-		throw new IllegalArgumentException("Unknown Main Category value: " + value);
+		throw new ClientBadRequestException("유효하지 않은 메인 유형 입니다: " + value + ". 가능한 값: " + getPossibleValues());
+	}
+
+	public static String getPossibleValues() {
+		StringBuilder sb = new StringBuilder();
+		for (AddReviewMainCategory category : AddReviewMainCategory.values()) {
+			sb.append(category.getValue()).append(", ");
+		}
+		return sb.substring(0, sb.length() - 2);
 	}
 }

--- a/src/main/java/sopt/org/homepage/review/dto/request/AddReviewRequestDto.java
+++ b/src/main/java/sopt/org/homepage/review/dto/request/AddReviewRequestDto.java
@@ -1,5 +1,7 @@
 package sopt.org.homepage.review.dto.request;
 
+import java.util.List;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
@@ -17,16 +19,22 @@ public class AddReviewRequestDto {
 	@NotEmpty(message = "기수 정보는 필수입니다")
 	private Integer generation;
 
-	@Schema(description = "파트(활동 기수)", requiredMode = Schema.RequiredMode.REQUIRED)
+	@Schema(description = "파트", requiredMode = Schema.RequiredMode.REQUIRED)
 	@NotEmpty(message = "파트 정보는 필수입니다")
 	private Part part;
 
-	@Schema(description = "주제", requiredMode = Schema.RequiredMode.REQUIRED)
-	@NotEmpty(message = "주제 정보는 필수입니다")
-	private String subject;
+	@Schema(description = "메인 유형", requiredMode = Schema.RequiredMode.REQUIRED, example = "전체 활동")
+	@NotEmpty(message = "메인 유형는 필수입니다")
+	private AddReviewMainCategory mainCategory;
+
+	@Schema(description = "활동 유형 (메인 유형 => 전체활동 선택 시 입력)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+	private List<AddReviewSubActivity> subActivities;
+
+	@Schema(description = "활동 유형 (메인 유형 => 서류/면접 선택 시 입력)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+	private AddReviewSubRecruiting subRecruiting;
 
 	@Schema(description = "작성자명", requiredMode = Schema.RequiredMode.REQUIRED)
-	@NotEmpty(message = "주제 정보는 필수입니다")
+	@NotEmpty(message = "작성자명 정보는 필수입니다")
 	private String author;
 
 	@Schema(description = "작성자 프로필 이미지", requiredMode = Schema.RequiredMode.NOT_REQUIRED)

--- a/src/main/java/sopt/org/homepage/review/dto/request/AddReviewSubActivity.java
+++ b/src/main/java/sopt/org/homepage/review/dto/request/AddReviewSubActivity.java
@@ -3,6 +3,8 @@ package sopt.org.homepage.review.dto.request;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import sopt.org.homepage.exception.ClientBadRequestException;
+
 public enum AddReviewSubActivity {
 	ALL("전체"),
 	APPJAM("앱잼"),
@@ -30,6 +32,14 @@ public enum AddReviewSubActivity {
 				return activity;
 			}
 		}
-		throw new IllegalArgumentException("Unknown Sub Activity value: " + value);
+		throw new ClientBadRequestException("유효하지 않은 세부 활동 입니다: " + value + ". 가능한 값: " + getPossibleValues());
+	}
+
+	public static String getPossibleValues() {
+		StringBuilder sb = new StringBuilder();
+		for (AddReviewSubActivity activity : AddReviewSubActivity.values()) {
+			sb.append(activity.getValue()).append(", ");
+		}
+		return sb.substring(0, sb.length() - 2);
 	}
 }

--- a/src/main/java/sopt/org/homepage/review/dto/request/AddReviewSubActivity.java
+++ b/src/main/java/sopt/org/homepage/review/dto/request/AddReviewSubActivity.java
@@ -1,0 +1,35 @@
+package sopt.org.homepage.review.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum AddReviewSubActivity {
+	ALL("전체"),
+	APPJAM("앱잼"),
+	SOPKATHON("솝커톤"),
+	SEMINAR("세미나"),
+	STUDY("스터디"),
+	SOPTERM("솝텀"),
+	MAKERS("메이커스");
+
+	private final String value;
+
+	AddReviewSubActivity(String value) {
+		this.value = value;
+	}
+
+	@JsonValue
+	public String getValue() {
+		return value;
+	}
+
+	@JsonCreator
+	public static AddReviewSubActivity from(String value) {
+		for (AddReviewSubActivity activity : AddReviewSubActivity.values()) {
+			if (activity.getValue().equals(value)) {
+				return activity;
+			}
+		}
+		throw new IllegalArgumentException("Unknown Sub Activity value: " + value);
+	}
+}

--- a/src/main/java/sopt/org/homepage/review/dto/request/AddReviewSubRecruiting.java
+++ b/src/main/java/sopt/org/homepage/review/dto/request/AddReviewSubRecruiting.java
@@ -3,6 +3,8 @@ package sopt.org.homepage.review.dto.request;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import sopt.org.homepage.exception.ClientBadRequestException;
+
 public enum AddReviewSubRecruiting {
 	ALL("서류/면접"),
 	RESUME("서류"),
@@ -26,6 +28,14 @@ public enum AddReviewSubRecruiting {
 				return recruiting;
 			}
 		}
-		throw new IllegalArgumentException("Unknown Sub Recruiting value: " + value);
+		throw new ClientBadRequestException("유효하지 않은 세부 유형입니다: " + value + ". 가능한 값: " + getPossibleValues());
+	}
+
+	public static String getPossibleValues() {
+		StringBuilder sb = new StringBuilder();
+		for (AddReviewSubRecruiting recruiting : AddReviewSubRecruiting.values()) {
+			sb.append(recruiting.getValue()).append(", ");
+		}
+		return sb.substring(0, sb.length() - 2);
 	}
 }

--- a/src/main/java/sopt/org/homepage/review/dto/request/AddReviewSubRecruiting.java
+++ b/src/main/java/sopt/org/homepage/review/dto/request/AddReviewSubRecruiting.java
@@ -1,0 +1,31 @@
+package sopt.org.homepage.review.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum AddReviewSubRecruiting {
+	ALL("서류/면접"),
+	RESUME("서류"),
+	INTERVIEW("면접");
+
+	private final String value;
+
+	AddReviewSubRecruiting(String value) {
+		this.value = value;
+	}
+
+	@JsonValue
+	public String getValue() {
+		return value;
+	}
+
+	@JsonCreator
+	public static AddReviewSubRecruiting from(String value) {
+		for (AddReviewSubRecruiting recruiting : AddReviewSubRecruiting.values()) {
+			if (recruiting.getValue().equals(value)) {
+				return recruiting;
+			}
+		}
+		throw new IllegalArgumentException("Unknown Sub Recruiting value: " + value);
+	}
+}

--- a/src/main/java/sopt/org/homepage/review/entity/ReviewEntity.java
+++ b/src/main/java/sopt/org/homepage/review/entity/ReviewEntity.java
@@ -1,5 +1,10 @@
 package sopt.org.homepage.review.entity;
 
+import java.util.List;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
 import jakarta.persistence.Basic;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -24,45 +29,60 @@ public class ReviewEntity {
 	@Id
 	@Column(name = "\"id\"", nullable = false)
 	private Long id;
+
 	@Basic
 	@Column(name = "\"title\"", nullable = false, length = 200)
 	private String title;
+
 	@Basic
 	@Column(name = "\"author\"", nullable = false, length = 20)
 	private String author;
+
 	@Basic
 	@Column(name = "\"generation\"", nullable = false)
 	private int generation;
+
 	@Enumerated(EnumType.STRING)
 	@Column(name = "\"part\"", nullable = false, length = 10)
 	private Part part;
+
 	@Basic
-	@Column(name = "\"subject\"", nullable = false, length = 20)
-	private String subject;
+	@Column(name = "\"category\"", nullable = false, length = 20)
+	private String category;
+
+	@JdbcTypeCode(SqlTypes.JSON)
+	@Column(name = "\"subject\"", nullable = false, columnDefinition = "text")
+	private List<String> subject;
+
 	@Basic
 	@Column(name = "\"thumbnailUrl\"", nullable = true, length = 500)
 	private String thumbnailUrl;
+
 	@Basic
 	@Column(name = "\"platform\"", nullable = false, length = 50)
 	private String platform;
+
 	@Basic
 	@Column(name = "\"url\"", nullable = false, length = 500)
 	private String url;
+
 	@Basic
 	@Column(name = "\"description\"", nullable = false, length = 600)
 	private String description;
+
 	@Basic
 	@Column(name = "\"authorProfileImageUrl\"", nullable = true, length = 500)
 	private String authorProfileImageUrl;
 
 	@Builder
-	public ReviewEntity(String title, String author, int generation, Part part,
-		String subject, String thumbnailUrl, String platform,
+	public ReviewEntity(String title, String author, int generation, Part part, String category,
+		List<String> subject, String thumbnailUrl, String platform,
 		String url, String description, String authorProfileImageUrl) {
 		this.title = title;
 		this.author = author;
 		this.generation = generation;
 		this.part = part;
+		this.category = category;
 		this.subject = subject;
 		this.thumbnailUrl = thumbnailUrl;
 		this.platform = platform;

--- a/src/main/java/sopt/org/homepage/review/service/ReviewServiceImpl.java
+++ b/src/main/java/sopt/org/homepage/review/service/ReviewServiceImpl.java
@@ -1,5 +1,6 @@
 package sopt.org.homepage.review.service;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -13,7 +14,11 @@ import sopt.org.homepage.common.dto.PaginateResponseDto;
 import sopt.org.homepage.common.mapper.ResponseMapper;
 import sopt.org.homepage.common.type.Part;
 import sopt.org.homepage.exception.BusinessLogicException;
+import sopt.org.homepage.exception.ClientBadRequestException;
+import sopt.org.homepage.review.dto.request.AddReviewMainCategory;
 import sopt.org.homepage.review.dto.request.AddReviewRequestDto;
+import sopt.org.homepage.review.dto.request.AddReviewSubActivity;
+import sopt.org.homepage.review.dto.request.AddReviewSubRecruiting;
 import sopt.org.homepage.review.dto.request.ReviewsRequestDto;
 import sopt.org.homepage.review.dto.response.ReviewsResponseDto;
 import sopt.org.homepage.review.entity.ReviewEntity;
@@ -73,21 +78,43 @@ public class ReviewServiceImpl implements ReviewService {
 
 		CreateScraperResponseDto scrapResult = scraperService.scrap(new ScrapArticleDto(dto.getLink()));
 
+		List<String> subjects = getReviewSubject(dto.getMainCategory(), dto.getSubActivities(), dto.getSubRecruiting());
+
 		ReviewEntity review = ReviewEntity.builder()
 			.thumbnailUrl(scrapResult.getThumbnailUrl())
 			.title(scrapResult.getTitle())
 			.description(scrapResult.getDescription())
 			.platform(scrapResult.getPlatform())
 			.url(dto.getLink())
-			.subject(dto.getSubject())
+			.category(dto.getMainCategory().getValue())
+			.subject(subjects)
 			.author(dto.getAuthor())
 			.part(dto.getPart())
-			.author(dto.getAuthor())
 			.authorProfileImageUrl(dto.getAuthorProfileImageUrl())
 			.generation(dto.getGeneration())
 			.build();
 
 		reviewRepository.save(review);
+	}
 
+	private List<String> getReviewSubject(AddReviewMainCategory mainCategory, List<AddReviewSubActivity> subActivities,
+		AddReviewSubRecruiting subRecruiting) {
+		List<String> subjects = new ArrayList<>();
+
+		if (mainCategory == AddReviewMainCategory.ACTIVITY) {
+			if (subActivities == null || subActivities.isEmpty()) {
+				throw new ClientBadRequestException("전체활동 카테고리의 세부 활동 유형을 선택해주세요.");
+			}
+			for (AddReviewSubActivity activity : subActivities) {
+				subjects.add(activity.getValue());
+			}
+		} else if (mainCategory == AddReviewMainCategory.RECRUITING) {
+			if (subRecruiting == null) {
+				throw new ClientBadRequestException("서류/면접 카테고리의 세부 유형을 선택해주세요.");
+			}
+			subjects.add(subRecruiting.getValue());
+		}
+
+		return subjects;
 	}
 }

--- a/src/main/java/sopt/org/homepage/sopticle/dto/request/CreateSopticleAuthorDto.java
+++ b/src/main/java/sopt/org/homepage/sopticle/dto/request/CreateSopticleAuthorDto.java
@@ -13,23 +13,23 @@ import lombok.NoArgsConstructor;
 @Schema(description = "솝티클 작성자 정보")
 public class CreateSopticleAuthorDto {
 
-    @Schema(description = "작성자 id", requiredMode = Schema.RequiredMode.REQUIRED)
-    @NotNull(message = "작성자 ID는 필수입니다")
-    private Long id;
+	@Schema(description = "작성자 id", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotNull(message = "작성자 ID는 필수입니다")
+	private Long id;
 
-    @Schema(description = "작성자 이름", requiredMode = Schema.RequiredMode.REQUIRED)
-    @NotEmpty(message = "작성자 이름은 필수입니다")
-    private String name;
+	@Schema(description = "작성자 이름", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotEmpty(message = "작성자 이름은 필수입니다")
+	private String name;
 
-    @Schema(description = "작성자 프로필 이미지")
-    private String profileImage;
+	@Schema(description = "작성자 프로필 이미지")
+	private String profileImage;
 
-    @Schema(description = "작성자 활동 기수", requiredMode = Schema.RequiredMode.REQUIRED)
-    @NotNull(message = "활동 기수는 필수입니다")
-    private Integer generation;
+	@Schema(description = "작성자 활동 기수", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotNull(message = "활동 기수는 필수입니다")
+	private Integer generation;
 
-    @Schema(description = "작성자 역할", requiredMode = Schema.RequiredMode.REQUIRED,
-            example = "웹")
-    @NotNull(message = "역할은 필수입니다")
-    private CreateSopticleAuthorRole part;
+	@Schema(description = "작성자 역할", requiredMode = Schema.RequiredMode.REQUIRED,
+		example = "WEB")
+	@NotNull(message = "역할은 필수입니다")
+	private CreateSopticleAuthorRole part;
 }

--- a/src/main/java/sopt/org/homepage/sopticle/dto/request/CreateSopticleAuthorRole.java
+++ b/src/main/java/sopt/org/homepage/sopticle/dto/request/CreateSopticleAuthorRole.java
@@ -4,42 +4,42 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum CreateSopticleAuthorRole {
-    WEB("웹"),
-    PLAN("기획"),
-    DESIGN("디자인"),
-    IOS("iOS"),
-    SERVER("서버"),
-    ANDROID("안드로이드"),
-    WEB_LEADER("웹 파트장"),
-    PLAN_LEADER("기획 파트장"),
-    DESIGN_LEADER("디자인 파트장"),
-    IOS_LEADER("iOS 파트장"),
-    SERVER_LEADER("서버 파트장"),
-    ANDROID_LEADER("안드로이드 파트장"),
-    PRESIDENT("회장"),
-    VICE_PRESIDENT("부회장"),
-    GENERAL_AFFAIRS("총무"),
-    OPERATION_LEADER("운영 팀장"),
-    MEDIA_LEADER("미디어 팀장");
+	WEB("WEB"),
+	PLAN("PLAN"),
+	DESIGN("DESIGN"),
+	IOS("iOS"),
+	SERVER("SERVER"),
+	ANDROID("ANDROID"),
+	WEB_LEADER("웹 파트장"),
+	PLAN_LEADER("기획 파트장"),
+	DESIGN_LEADER("디자인 파트장"),
+	IOS_LEADER("iOS 파트장"),
+	SERVER_LEADER("서버 파트장"),
+	ANDROID_LEADER("안드로이드 파트장"),
+	PRESIDENT("회장"),
+	VICE_PRESIDENT("부회장"),
+	GENERAL_AFFAIRS("총무"),
+	OPERATION_LEADER("운영 팀장"),
+	MEDIA_LEADER("미디어 팀장");
 
-    private final String value;
+	private final String value;
 
-    CreateSopticleAuthorRole(String value) {
-        this.value = value;
-    }
+	CreateSopticleAuthorRole(String value) {
+		this.value = value;
+	}
 
-    @JsonValue  // 직렬화 시 한글 값 사용
-    public String getValue() {
-        return value;
-    }
+	@JsonValue  // 직렬화 시 한글 값 사용
+	public String getValue() {
+		return value;
+	}
 
-    @JsonCreator  // 역직렬화 시 한글 값으로부터 enum 생성
-    public static CreateSopticleAuthorRole from(String value) {
-        for (CreateSopticleAuthorRole role : CreateSopticleAuthorRole.values()) {
-            if (role.getValue().equals(value)) {
-                return role;
-            }
-        }
-        throw new IllegalArgumentException("Unknown role value: " + value);
-    }
+	@JsonCreator  // 역직렬화 시 한글 값으로부터 enum 생성
+	public static CreateSopticleAuthorRole from(String value) {
+		for (CreateSopticleAuthorRole role : CreateSopticleAuthorRole.values()) {
+			if (role.getValue().equals(value)) {
+				return role;
+			}
+		}
+		throw new IllegalArgumentException("Unknown role value: " + value);
+	}
 }

--- a/src/main/java/sopt/org/homepage/sopticle/dto/request/CreateSopticleDto.java
+++ b/src/main/java/sopt/org/homepage/sopticle/dto/request/CreateSopticleDto.java
@@ -3,12 +3,9 @@ package sopt.org.homepage.sopticle.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -16,16 +13,12 @@ import java.util.List;
 @Schema(description = "솝티클 생성 요청")
 public class CreateSopticleDto {
 
-    @Schema(description = "pg에서 생성한 솝티클 id 입니다., 공홈 SopticleID와 같습니다. ( 추후 Sync가 맞지 않는다면 분리를 해야 할 수도 있을것 같아요)", requiredMode = Schema.RequiredMode.REQUIRED)
-    @NotNull(message = "솝티클 ID는 필수입니다")
-    private Long id;
+	@Schema(description = "솝티클 주소", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotEmpty(message = "솝티클 주소는 필수입니다")
+	private String link;
 
-    @Schema(description = "솝티클 주소", requiredMode = Schema.RequiredMode.REQUIRED)
-    @NotEmpty(message = "솝티클 주소는 필수입니다")
-    private String link;
-
-    @Schema(description = "작성자 정보 목록", requiredMode = Schema.RequiredMode.REQUIRED)
-    @NotEmpty(message = "작성자 정보는 필수입니다")
-    @Valid
-    private List<CreateSopticleAuthorDto> authors;
+	@Schema(description = "작성자 정보", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotEmpty(message = "작성자 정보는 필수입니다")
+	@Valid
+	private CreateSopticleAuthorDto author;
 }

--- a/src/main/java/sopt/org/homepage/sopticle/entity/SopticleAuthorEntity.java
+++ b/src/main/java/sopt/org/homepage/sopticle/entity/SopticleAuthorEntity.java
@@ -1,13 +1,22 @@
 package sopt.org.homepage.sopticle.entity;
 
-import jakarta.persistence.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.util.Objects;
+import jakarta.persistence.Basic;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
@@ -15,45 +24,44 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "\"SopticleAuthor\"")
 public class SopticleAuthorEntity {
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Id
-    @Column(name = "\"id\"", nullable = false)
-    private int id;
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Id
+	@Column(name = "\"id\"", nullable = false)
+	private int id;
 
-    @Basic
-    @Column(name = "\"pgUserId\"", nullable = false)
-    private Long pgUserId;
+	@Basic
+	@Column(name = "\"pgUserId\"", nullable = false)
+	private Long pgUserId;
 
-    @Basic
-    @Column(name = "\"name\"", nullable = false, length = 20)
-    private String name;
+	@Basic
+	@Column(name = "\"name\"", nullable = false, length = 20)
+	private String name;
 
-    @Basic
-    @Column(name = "\"profileImage\"", nullable = true, length = 500)
-    private String profileImage;
+	@Basic
+	@Column(name = "\"profileImage\"", nullable = true, length = 500)
+	private String profileImage;
 
-    @Basic
-    @Column(name = "\"generation\"", nullable = false)
-    private int generation;
+	@Basic
+	@Column(name = "\"generation\"", nullable = false)
+	private int generation;
 
-    @Basic
-    @Column(name = "\"part\"", nullable = false, length = 20)
-    private String part;
+	@Basic
+	@Column(name = "\"part\"", nullable = false, length = 20)
+	private String part;
 
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "\"sopticleId\"")
+	private SopticleEntity sopticle;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "\"sopticleId\"")
-    private SopticleEntity sopticle;
-
-    @Builder
-    private SopticleAuthorEntity(SopticleEntity sopticle, Long pgUserId, String name,
-                                 String profileImage, Integer generation, String part) {
-        this.sopticle = sopticle;
-        this.pgUserId = pgUserId;
-        this.name = name;
-        this.profileImage = profileImage;
-        this.generation = generation;
-        this.part = part;
-    }
+	@Builder
+	private SopticleAuthorEntity(SopticleEntity sopticle, Long pgUserId, String name,
+		String profileImage, Integer generation, String part) {
+		this.sopticle = sopticle;
+		this.pgUserId = pgUserId;
+		this.name = name;
+		this.profileImage = profileImage;
+		this.generation = generation;
+		this.part = part;
+	}
 
 }

--- a/src/main/java/sopt/org/homepage/sopticle/entity/SopticleEntity.java
+++ b/src/main/java/sopt/org/homepage/sopticle/entity/SopticleEntity.java
@@ -1,16 +1,26 @@
 package sopt.org.homepage.sopticle.entity;
 
-import jakarta.persistence.*;
-
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import jakarta.persistence.Basic;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
 import sopt.org.homepage.common.type.Part;
 
 @Entity
@@ -18,91 +28,68 @@ import sopt.org.homepage.common.type.Part;
 @Table(name = "\"Sopticle\"")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SopticleEntity {
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Id
-    @Column(name = "\"id\"", nullable = false)
-    private Long id;
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Id
+	@Column(name = "\"id\"", nullable = false)
+	private Long id;
 
-    @Getter
-    @Enumerated(EnumType.STRING)
-    @Column(name = "\"part\"")
-    private Part part;
+	@Getter
+	@Enumerated(EnumType.STRING)
+	@Column(name = "\"part\"")
+	private Part part;
 
-    @Basic
-    @Column(name = "\"generation\"", nullable = false)
-    private int generation;
+	@Basic
+	@Column(name = "\"generation\"", nullable = false)
+	private int generation;
 
-    @Basic
-    @Column(name = "\"thumbnailUrl\"", nullable = true, length = 500)
-    private String thumbnailUrl;
+	@Basic
+	@Column(name = "\"thumbnailUrl\"", nullable = true, length = 500)
+	private String thumbnailUrl;
 
-    @Basic
-    @Column(name = "\"title\"", nullable = false, length = 100)
-    private String title;
+	@Basic
+	@Column(name = "\"title\"", nullable = false, length = 100)
+	private String title;
 
-    @Basic
-    @Column(name = "\"description\"", nullable = false, length = 600)
-    private String description;
+	@Basic
+	@Column(name = "\"description\"", nullable = false, length = 600)
+	private String description;
 
-    @Basic
-    @Column(name = "\"authorId\"", nullable = false)
-    private Long authorId;
+	@Basic
+	@Column(name = "\"sopticleUrl\"", nullable = false, length = 500)
+	private String sopticleUrl;
 
-    @Basic
-    @Column(name = "\"authorName\"", nullable = false, length = 20)
-    private String authorName;
+	@CreationTimestamp
+	@Basic
+	@Column(name = "\"createdAt\"", nullable = false)
+	private LocalDateTime createdAt;
 
-    @Basic
-    @Column(name = "\"authorProfileImageUrl\"", nullable = true, length = 500)
-    private String authorProfileImageUrl;
+	@Basic
+	@Column(name = "\"likeCount\"", nullable = false)
+	private int likeCount;
 
-    @Basic
-    @Column(name = "\"sopticleUrl\"", nullable = false, length = 500)
-    private String sopticleUrl;
+	@OneToMany(mappedBy = "sopticle", cascade = CascadeType.ALL)
+	private List<SopticleLikeEntity> sopticleLikes;
 
-    @CreationTimestamp
-    @Basic
-    @Column(name = "\"createdAt\"", nullable = false)
-    private LocalDateTime createdAt;
+	@OneToOne(mappedBy = "sopticle", cascade = CascadeType.ALL, orphanRemoval = true)
+	private SopticleAuthorEntity author;
 
-    @Basic
-    @Column(name = "\"likeCount\"", nullable = false)
-    private int likeCount;
+	public void incrementLikeCount() {
+		this.likeCount++;
+	}
 
-    @Basic
-    @Column(name = "\"pgSopticleId\"", nullable = false)
-    private Long pgSopticleId;
+	public void decrementLikeCount() {
+		this.likeCount--;
+	}
 
-    @OneToMany(mappedBy = "sopticle", cascade = CascadeType.ALL)
-    private List<SopticleLikeEntity> sopticleLikes;
-
-    @OneToMany(mappedBy = "sopticle", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<SopticleAuthorEntity> authors = new ArrayList<>();
-
-
-    public void incrementLikeCount() {
-        this.likeCount++;
-    }
-
-    public void decrementLikeCount() {
-        this.likeCount--;
-    }
-
-    @Builder
-    private SopticleEntity(Part part, Integer generation, String thumbnailUrl, String title,
-                           String description, Long authorId, String authorName,
-                           String authorProfileImageUrl, String sopticleUrl, Long pgSopticleId) {
-        this.part = part;
-        this.generation = generation;
-        this.thumbnailUrl = thumbnailUrl;
-        this.title = title;
-        this.description = description;
-        this.authorId = authorId;
-        this.authorName = authorName;
-        this.authorProfileImageUrl = authorProfileImageUrl;
-        this.sopticleUrl = sopticleUrl;
-        this.pgSopticleId = pgSopticleId;
-    }
-
+	@Builder
+	private SopticleEntity(Part part, Integer generation, String thumbnailUrl, String title,
+		String description, String sopticleUrl) {
+		this.part = part;
+		this.generation = generation;
+		this.thumbnailUrl = thumbnailUrl;
+		this.title = title;
+		this.description = description;
+		this.sopticleUrl = sopticleUrl;
+	}
 
 }


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- #45 

## Work Description ✏️
- 활동후기
  - 활동후기가 플레이그라운드에서 직접 추가가 가능하게 되도록 변경되어, 플그 추가 뷰에 맞게 기존 활동후기 추가 API 와 Review Entity 를 수정하였습니다. (DB 마이그레이션은 수작업으로 진행하였음)
  - 테이블 변경사항
    - 기존 ```String subject``` (활동) ⇒ ```List<String> subject``` (여러 활동 입력가능)
    - String category (전체활동/서류면접) 컬럼 추가
- 솝티클
  - [[참고 스레드]](https://sopt-makers.slack.com/archives/C04SPCUJ2DQ/p1745222225300239)
  - 플그 솝티클 ID 제거
  - 플그 작성자 정보 Sopticle 테이블과 Sopticle Author 테이블에 중복되는 부분 제거
  - authors ⇒ author 단일 객체로 변경

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
  - Dev 는 DB 마이그레이션 타이밍을 고려하지 않고 작업하였지만, 상용환경의 경우, 배포 시간에 맞추어 DB 마이그레이션을 진행할 예정입니다!
