### PR TITLE
[FEAT] 활동후기 조회 화면 개편사항 작업

### DIFF
--- a/src/main/java/sopt/org/homepage/common/mapper/ResponseMapper.java
+++ b/src/main/java/sopt/org/homepage/common/mapper/ResponseMapper.java
@@ -1,7 +1,9 @@
 package sopt.org.homepage.common.mapper;
 
+import java.util.List;
+
 import org.springframework.stereotype.Component;
-import sopt.org.homepage.review.entity.ReviewEntity;
+
 import sopt.org.homepage.internal.playground.dto.PlaygroundProjectDetailResponse;
 import sopt.org.homepage.internal.playground.dto.PlaygroundProjectResponseDto;
 import sopt.org.homepage.internal.playground.dto.Role;
@@ -12,108 +14,92 @@ import sopt.org.homepage.project.dto.response.ProjectDetailResponseDto;
 import sopt.org.homepage.project.dto.response.ProjectsResponseDto;
 import sopt.org.homepage.project.dto.type.LinkType;
 import sopt.org.homepage.review.dto.response.ReviewsResponseDto;
+import sopt.org.homepage.review.entity.ReviewEntity;
 import sopt.org.homepage.semester.dto.SemesterDao;
 import sopt.org.homepage.semester.dto.SemestersListResponse;
-
-import java.util.List;
 
 @Component
 public class ResponseMapper {
 
-    public SemestersListResponse.SemestersResponse toSemestersResponse(SemesterDao semester) {
-        return new SemestersListResponse.SemestersResponse(
-                semester.id(), semester.color(), semester.logo(), semester.background(), semester.name(), semester.year()
-        );
-    }
+	public SemestersListResponse.SemestersResponse toSemestersResponse(SemesterDao semester) {
+		return new SemestersListResponse.SemestersResponse(
+			semester.id(), semester.color(), semester.logo(), semester.background(), semester.name(), semester.year()
+		);
+	}
 
+	public ProjectsResponseDto toProjectResponse(PlaygroundProjectResponseDto project) {
+		List<Link> links = project.links().stream()
+			.map(link -> new Link(LinkType.fromValue(link.linkTitle()), link.linkUrl()))
+			.toList();
+		Category category = new Category(project.category());
 
+		return ProjectsResponseDto.builder()
+			.id(project.id())
+			.name(project.name())
+			.generation(project.generation())
+			.category(category)
+			.serviceType(project.serviceType())
+			.summary(project.summary())
+			.detail(project.detail())
+			.logoImage(project.logoImage())
+			.thumbnailImage(project.thumbnailImage())
+			.isAvailable(project.isAvailable())
+			.isFounding(project.isFounding())
+			.links(links)
+			.build();
+	}
 
-    public ProjectsResponseDto toProjectResponse(PlaygroundProjectResponseDto project) {
-        List<Link> links = project.links().stream()
-                .map(link -> new Link(LinkType.fromValue(link.linkTitle()), link.linkUrl()))
-                .toList();
-        Category category = new Category(project.category());
+	public ProjectDetailResponseDto toProjectDetailResponse(PlaygroundProjectDetailResponse project) {
+		List<Link> links = project.links().stream()
+			.map(link -> new Link(LinkType.fromValue(link.linkTitle()), link.linkUrl()))
+			.toList();
+		Category category = new Category(project.category());
+		List<Member> members = project.members().stream()
+			.map(member -> new Member(
+				member.memberName(),
+				Role.fromValue(member.memberRole()),
+				member.memberDescription()
+			))
+			.toList();
+		String projectImage = project.images().isEmpty() ? null : project.images().get(0);
 
-        return ProjectsResponseDto.builder()
-                .id(project.id())
-                .name(project.name())
-                .generation(project.generation())
-                .category(category)
-                .serviceType(project.serviceType())
-                .summary(project.summary())
-                .detail(project.detail())
-                .logoImage(project.logoImage())
-                .thumbnailImage(project.thumbnailImage())
-                .isAvailable(project.isAvailable())
-                .isFounding(project.isFounding())
-                .links(links)
-                .build();
-    }
+		return ProjectDetailResponseDto.builder()
+			.id(project.id())
+			.name(project.name())
+			.generation(project.generation())
+			.category(category)
+			.projectImage(projectImage)
+			.serviceType(project.serviceType())
+			.summary(project.summary())
+			.detail(project.detail())
+			.logoImage(project.logoImage())
+			.thumbnailImage(project.thumbnailImage())
+			.isAvailable(project.isAvailable())
+			.isFounding(project.isFounding())
+			.links(links)
+			.startAt(project.startAt())
+			.endAt(project.endAt())
+			.uploadedAt(project.createdAt())
+			.updatedAt(project.updatedAt())
+			.members(members)
+			.build();
+	}
 
-
-    public ProjectDetailResponseDto toProjectDetailResponse(PlaygroundProjectDetailResponse project) {
-        List<Link> links = project.links().stream()
-                .map(link -> new Link(LinkType.fromValue(link.linkTitle()), link.linkUrl()))
-                .toList();
-        Category category = new Category(project.category());
-        List<Member> members = project.members().stream()
-                .map(member -> new Member(
-                        member.memberName(),
-                        Role.fromValue(member.memberRole()),
-                        member.memberDescription()
-                ))
-                .toList();
-        String projectImage = project.images().isEmpty() ? null : project.images().get(0);
-
-        return ProjectDetailResponseDto.builder()
-                .id(project.id())
-                .name(project.name())
-                .generation(project.generation())
-                .category(category)
-                .projectImage(projectImage)
-                .serviceType(project.serviceType())
-                .summary(project.summary())
-                .detail(project.detail())
-                .logoImage(project.logoImage())
-                .thumbnailImage(project.thumbnailImage())
-                .isAvailable(project.isAvailable())
-                .isFounding(project.isFounding())
-                .links(links)
-                .startAt(project.startAt())
-                .endAt(project.endAt())
-                .uploadedAt(project.createdAt())
-                .updatedAt(project.updatedAt())
-                .members(members)
-                .build();
-    }
-
-    public ReviewsResponseDto toReviewResponseDto(ReviewEntity entity) {
-        // subject List<String>을 단일 String으로 변환
-        String subjectStr;
-        List<String> subjects = entity.getSubject();
-        
-        if (subjects == null || subjects.isEmpty()) {
-            subjectStr = "";
-        } else if (subjects.size() == 1) {
-            // 배열 길이가 1이면 그 값만 사용
-            subjectStr = subjects.get(0);
-        } else {
-            // 배열 길이가 2 이상이면 " | "로 구분하여 하나의 문자열로 결합
-            subjectStr = String.join(" | ", subjects);
-        }
-        
-        return ReviewsResponseDto.builder()
-                .id(entity.getId())
-                .title(entity.getTitle())
-                .author(entity.getAuthor())
-                .authorProfileImageUrl(entity.getAuthorProfileImageUrl())
-                .generation(entity.getGeneration())
-                .description(entity.getDescription())
-                .part(entity.getPart())
-                .subject(subjectStr)
-                .thumbnailUrl(entity.getThumbnailUrl())
-                .platform(entity.getPlatform())
-                .url(entity.getUrl())
-                .build();
-    }
+	public ReviewsResponseDto toReviewResponseDto(ReviewEntity entity) {
+		
+		return ReviewsResponseDto.builder()
+			.id(entity.getId())
+			.title(entity.getTitle())
+			.category(entity.getCategory())
+			.author(entity.getAuthor())
+			.authorProfileImageUrl(entity.getAuthorProfileImageUrl())
+			.generation(entity.getGeneration())
+			.description(entity.getDescription())
+			.part(entity.getPart())
+			.subject(entity.getSubject())
+			.thumbnailUrl(entity.getThumbnailUrl())
+			.platform(entity.getPlatform())
+			.url(entity.getUrl())
+			.build();
+	}
 }

--- a/src/main/java/sopt/org/homepage/review/dto/request/ReviewsRequestDto.java
+++ b/src/main/java/sopt/org/homepage/review/dto/request/ReviewsRequestDto.java
@@ -1,9 +1,10 @@
 package sopt.org.homepage.review.dto.request;
 
+import org.springframework.validation.annotation.Validated;
+
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
-import org.springframework.validation.annotation.Validated;
 import sopt.org.homepage.common.dto.PaginateRequest;
 import sopt.org.homepage.common.type.Part;
 
@@ -11,15 +12,26 @@ import sopt.org.homepage.common.type.Part;
 @Getter
 @Schema(description = "리뷰 조회 요청")
 public class ReviewsRequestDto extends PaginateRequest {
-    @Parameter(description = "Part, 전체를 불러올땐 아무값도 안넣으면 됩니다.")
-    private final Part part;
+	@Parameter(description = "메인 카테고리 => [서류/면접] or [전체 활동](=활동 후기) 둘 중 하나의 값으로 넣어주시면 됩니다.", required = true)
+	@Schema(allowableValues = {"서류/면접", "전체 활동"}, type = "string")
+	private final String category;
 
-    @Parameter(description = "활동기수로 필터링 합니다, 값을 넣지 않을 경우 전체 조회합니다.")
-    private final Integer generation;
+	@Parameter(description = "활동 후기 세부 항목 => 카테고리에서 [전체 활동]을 선택한 경우에만 입력하면 됩니다. ([전체] 입력 시, 모두 조회)", required = false)
+	@Schema(allowableValues = {"전체", "앱잼", "솝커톤", "세미나", "스터디", "솝텀", "메이커스"}, type = "string")
+	private final String activity;
 
-    public ReviewsRequestDto(Integer pageNo, Integer limit, Part part, Integer generation) {
-        super(pageNo, limit);
-        this.part = part;
-        this.generation = generation;
-    }
+	@Parameter(description = "파트 => 전체를 불러올땐 아무값도 안넣으면 됩니다.", required = false)
+	private final Part part;
+
+	@Parameter(description = "활동기수 => 전체를 불러올땐 아무값도 안넣으면 됩니다.", required = false)
+	private final Integer generation;
+
+	public ReviewsRequestDto(Integer pageNo, Integer limit, String category, String activity,
+		Part part, Integer generation) {
+		super(pageNo, limit);
+		this.category = category;
+		this.activity = activity;
+		this.part = part;
+		this.generation = generation;
+	}
 }

--- a/src/main/java/sopt/org/homepage/review/dto/response/ReviewsResponseDto.java
+++ b/src/main/java/sopt/org/homepage/review/dto/response/ReviewsResponseDto.java
@@ -1,5 +1,7 @@
 package sopt.org.homepage.review.dto.response;
 
+import java.util.List;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,53 +11,57 @@ import sopt.org.homepage.common.type.Part;
 @Getter
 public class ReviewsResponseDto {
 
-    @Schema(description = "리뷰 ID(item의 기본 키)")
-    private final Long id;
+	@Schema(description = "리뷰 ID(item의 기본 키)")
+	private final Long id;
 
-    @Schema(description = "활동 리뷰 타이틀")
-    private final String title;
+	@Schema(description = "활동 리뷰 타이틀")
+	private final String title;
 
-    @Schema(description = "작성자")
-    private final String author;
+	@Schema(description = "작성자")
+	private final String author;
 
-    @Schema(description = "작성자 프로필 이미지")
-    private final String authorProfileImageUrl;
+	@Schema(description = "작성자 프로필 이미지")
+	private final String authorProfileImageUrl;
 
-    @Schema(description = "활동 기수")
-    private final Integer generation;
+	@Schema(description = "활동 기수")
+	private final Integer generation;
 
-    @Schema(description = "활동후기 설명")
-    private final String description;
+	@Schema(description = "활동후기 설명")
+	private final String description;
 
-    @Schema(description = "파트(활동 기수)")
-    private final Part part;
+	@Schema(description = "파트(활동 기수)")
+	private final Part part;
 
-    @Schema(description = "주제")
-    private final String subject;
+	@Schema(description = "카테고리")
+	private final String category;
 
-    @Schema(description = "썸네일 URL(활동후기 타이틀)")
-    private final String thumbnailUrl;
+	@Schema(description = "주제")
+	private final List<String> subject;
 
-    @Schema(description = "후기 작성 플랫폼")
-    private final String platform;
+	@Schema(description = "썸네일 URL(활동후기 타이틀)")
+	private final String thumbnailUrl;
 
-    @Schema(description = "Redirect Link")
-    private final String url;
+	@Schema(description = "후기 작성 플랫폼")
+	private final String platform;
 
-    @Builder
-    private ReviewsResponseDto(Long id, String title, String author, String authorProfileImageUrl,
-                               Integer generation, String description, Part part, String subject,
-                               String thumbnailUrl, String platform, String url) {
-        this.id = id;
-        this.title = title;
-        this.author = author;
-        this.authorProfileImageUrl = authorProfileImageUrl;
-        this.generation = generation;
-        this.description = description;
-        this.part = part;
-        this.subject = subject;
-        this.thumbnailUrl = thumbnailUrl;
-        this.platform = platform;
-        this.url = url;
-    }
+	@Schema(description = "Redirect Link")
+	private final String url;
+
+	@Builder
+	private ReviewsResponseDto(Long id, String title, String category, String author, String authorProfileImageUrl,
+		Integer generation, String description, Part part, List<String> subject,
+		String thumbnailUrl, String platform, String url) {
+		this.id = id;
+		this.title = title;
+		this.category = category;
+		this.author = author;
+		this.authorProfileImageUrl = authorProfileImageUrl;
+		this.generation = generation;
+		this.description = description;
+		this.part = part;
+		this.subject = subject;
+		this.thumbnailUrl = thumbnailUrl;
+		this.platform = platform;
+		this.url = url;
+	}
 }


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- #50 

## Work Description ✏️
- 활동 후기 API 수정
  - Response 필드 변경
    - subject String 타입 ⇒ List<String> 변경 (세부 항목 다중 선택)
    - category 필드 추가 (서류/면접 or 전체 활동)
  - Request 필터링 조건 추가
    - category 필드 추가 (서류/면접 or 전체 활동)
    - activity 필드 추가 (활동 후기 세부항목 설정) 

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
* 자동 Linting 으로 인하여 많이 수정된 것 처럼 보이지만, 사실 변경된 부분은 그렇게 많지 않습니다...! 보시는데 불편을 야기해서 죄송합니다ㅠㅠ
* Request Query DTO 에서 category 와 activity 또한 ENUM 으로 처리하고 싶었지만, Query 에 한글 값을 넣으면 인코딩 문제로 역직렬화 과정에서 ENUM Value로 인식하지 못하는 발생해서, String으로 타입을 받고 대신에 Swagger 명세에 가능한 값을 선택형으로 넣어두었습니다.
* 활동 후기 세부 항목이 입력되는 경우, 다음과 같은 QueryDSL 조건을 붙여서 조회하게 되는데 성능이 썩 좋지는 못할겁니다,,
```
  		if (Objects.equals(requestDto.getCategory(), "전체 활동") && requestDto.getActivity() != null
			&& !requestDto.getActivity().equals("전체")) {
			String searchTerm = "\"" + requestDto.getActivity() + "\"";

			BooleanExpression subjectContains = Expressions.booleanTemplate(
				"CAST({0} AS string) LIKE {1}",
				review.subject,
				"%" + searchTerm + "%"
			);

			query.where(subjectContains);

		}
```
  * <img width="525" alt="스크린샷 2025-04-29 오후 11 50 08" src="https://github.com/user-attachments/assets/1292fcd7-3c4a-440f-900c-3fa8f5df0924" />
  *  위와 같이, subject 컬럼을 text 타입의 String 배열로 처리해놓아서, 세부 항목 입력 시 다음과 같은 예시로 where 조건이 추가 됩니다
    * ``` subject LIKE "%메이커스%"; ``` 
    * 쿼리 성능이 좋지는 않지만,, 활동후기 데이터가 그렇게 많지는 않기에 우선 이렇게 구현해놓았습니다ㅠ
