### PR TITLE
[FEAT] 솝트 이야기 좋아요 시,  sessionID 대신 사용자의 IP 로 중복여부 판단

### DIFF
--- a/src/main/java/sopt/org/homepage/common/util/IpAddressUtil.java
+++ b/src/main/java/sopt/org/homepage/common/util/IpAddressUtil.java
@@ -1,0 +1,86 @@
+package sopt.org.homepage.common.util;
+
+import org.springframework.util.StringUtils;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public class IpAddressUtil {
+
+	private static final String[] IP_HEADER_CANDIDATES = {
+		"X-Forwarded-For",
+		"Proxy-Client-IP",
+		"WL-Proxy-Client-IP",
+		"HTTP_X_FORWARDED_FOR",
+		"HTTP_X_FORWARDED",
+		"HTTP_X_CLUSTER_CLIENT_IP",
+		"HTTP_CLIENT_IP",
+		"HTTP_FORWARDED_FOR",
+		"HTTP_FORWARDED",
+		"HTTP_VIA",
+		"REMOTE_ADDR"
+	};
+
+	/**
+	 * HttpServletRequest에서 클라이언트의 실제 IP 주소를 추출합니다.
+	 * 프록시나 로드밸런서를 통한 요청의 경우 원본 IP를 찾아 반환합니다.
+	 *
+	 * @param request HttpServletRequest 객체
+	 * @return 클라이언트의 IP 주소
+	 */
+	public static String getClientIpAddress(HttpServletRequest request) {
+		for (String header : IP_HEADER_CANDIDATES) {
+			String ip = request.getHeader(header);
+			if (StringUtils.hasText(ip) && !"unknown".equalsIgnoreCase(ip)) {
+				// X-Forwarded-For 헤더의 경우 여러 IP가 콤마로 구분되어 있을 수 있음
+				// 첫 번째 IP가 원본 클라이언트 IP
+				if (ip.contains(",")) {
+					ip = ip.split(",")[0].trim();
+				}
+				return normalizeIpAddress(ip);
+			}
+		}
+
+		// 헤더에서 IP를 찾지 못한 경우 기본 remote address 사용
+		return normalizeIpAddress(request.getRemoteAddr());
+	}
+
+	/**
+	 * IP 주소를 정규화합니다. (IPv6 전체 형태를 축약 형태로 변환)
+	 *
+	 * @param ip 원본 IP 주소
+	 * @return 정규화된 IP 주소
+	 */
+	private static String normalizeIpAddress(String ip) {
+		if (ip == null) {
+			return "127.0.0.1";
+		}
+
+		// IPv6 localhost 전체 형태를 축약 형태로 변환
+		if ("0:0:0:0:0:0:0:1".equals(ip)) {
+			return "::1";
+		}
+
+		return ip;
+	}
+
+	/**
+	 * IP 주소가 유효한지 검증합니다.
+	 *
+	 * @param ip 검증할 IP 주소
+	 * @return 유효한 IP 주소인지 여부
+	 */
+	public static boolean isValidIpAddress(String ip) {
+		if (!StringUtils.hasText(ip) || "unknown".equalsIgnoreCase(ip)) {
+			return false;
+		}
+
+		// IPv4 주소 패턴 검증 (간단한 형태)
+		String ipv4Pattern = "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$";
+
+		// IPv6 주소 패턴 검증 (간단한 형태)
+		String ipv6Pattern = "^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$";
+
+		return ip.matches(ipv4Pattern) || ip.matches(ipv6Pattern) ||
+			"localhost".equals(ip) || "127.0.0.1".equals(ip) || "::1".equals(ip);
+	}
+}

--- a/src/main/java/sopt/org/homepage/soptstory/SoptStoryController.java
+++ b/src/main/java/sopt/org/homepage/soptstory/SoptStoryController.java
@@ -2,6 +2,7 @@ package sopt.org.homepage.soptstory;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 import sopt.org.homepage.common.dto.PaginateResponseDto;
+import sopt.org.homepage.common.util.IpAddressUtil;
 import sopt.org.homepage.config.AuthConfig;
 import sopt.org.homepage.exception.BusinessLogicException;
 import sopt.org.homepage.soptstory.dto.request.CreateSoptStoryDto;
@@ -39,37 +41,40 @@ public class SoptStoryController {
     @Operation(summary = "솝트스토리 리스트 조회(정렬)")
     public ResponseEntity<PaginateResponseDto<SoptStoryResponseDto>> getSoptStoryList(
             @ParameterObject @ModelAttribute GetSoptStoryListRequestDto getSoptStoryListRequestDto,
-            @RequestHeader(value = "session-id", required = false) String session
+            HttpServletRequest request
     ) {
-        if (session == null) {
+        String ip = IpAddressUtil.getClientIpAddress(request);
+        if (!IpAddressUtil.isValidIpAddress(ip)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-                    "session-id is required");
+                    "Unable to determine client IP address");
         }
-        return ResponseEntity.ok(soptStoryService.paginateSoptStorys(getSoptStoryListRequestDto, session));
+        return ResponseEntity.ok(soptStoryService.paginateSoptStorys(getSoptStoryListRequestDto, ip));
     }
 
     @Operation(summary = "솝트스토리 좋아요 누르기")
     @PostMapping("/{id}/like")
     public ResponseEntity<LikeSoptStoryResponseDto> likeSoptStory(
             @PathVariable Long id,
-            @RequestHeader(value = "session-id", required = false) String session
+            HttpServletRequest request
     ) {
-        if (session == null) {
-            throw new BusinessLogicException("session-id is required");
+        String ip = IpAddressUtil.getClientIpAddress(request);
+        if (!IpAddressUtil.isValidIpAddress(ip)) {
+            throw new BusinessLogicException("Unable to determine client IP address");
         }
-        return ResponseEntity.ok(soptStoryService.like(id, session));
+        return ResponseEntity.ok(soptStoryService.like(id, ip));
     }
 
     @Operation(summary = "솝트 스토리 좋아요 취소하기")
     @PostMapping("/{id}/unlike")
     public ResponseEntity<LikeSoptStoryResponseDto> unlikeSoptStory(
             @PathVariable Long id,
-            @RequestHeader(value = "session-id", required = false) String session
+            HttpServletRequest request
     ) {
-        if (session == null) {
-            throw new BusinessLogicException("session-id is required");
+        String ip = IpAddressUtil.getClientIpAddress(request);
+        if (!IpAddressUtil.isValidIpAddress(ip)) {
+            throw new BusinessLogicException("Unable to determine client IP address");
         }
-        return ResponseEntity.ok(soptStoryService.unlike(id, session));
+        return ResponseEntity.ok(soptStoryService.unlike(id, ip));
     }
 
     @PostMapping

--- a/src/main/java/sopt/org/homepage/soptstory/dto/response/LikeSoptStoryResponseDto.java
+++ b/src/main/java/sopt/org/homepage/soptstory/dto/response/LikeSoptStoryResponseDto.java
@@ -13,7 +13,7 @@ public class LikeSoptStoryResponseDto {
     @Schema(description = "soptStory Id")
     private final Long soptStoryId;
 
-    @Schema(description = "session Id")
-    private final String sessionId;
+    @Schema(description = "IP address")
+    private final String ip;
 
 }

--- a/src/main/java/sopt/org/homepage/soptstory/dto/response/SoptStoryResponseDto.java
+++ b/src/main/java/sopt/org/homepage/soptstory/dto/response/SoptStoryResponseDto.java
@@ -1,7 +1,8 @@
 package sopt.org.homepage.soptstory.dto.response;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,26 +10,28 @@ import lombok.Getter;
 @Getter
 @Builder
 public class SoptStoryResponseDto {
-    @Schema(description = "SoptStory Id")
-    private final Long id;
+	@Schema(description = "SoptStory Id")
+	private final Long id;
 
-    @Schema(description = "솝트스토리 썸네일 이미지")
-    private final String thumbnailUrl;
+	@Schema(description = "솝트스토리 썸네일 이미지")
+	private final String thumbnailUrl;
 
-    @Schema(description = "솝트스토리 제목")
-    private final String title;
+	@Schema(description = "솝트스토리 제목")
+	private final String title;
 
-    @Schema(description = "솝트스토리 설명")
-    private final String description;
+	@Schema(description = "솝트스토리 설명")
+	private final String description;
 
+	@Schema(description = "솝트스토리 리다이렉트 주소")
+	private final String url;
 
-    @Schema(description = "솝트스토리 리다이렉트 주소")
-    private final String url;
+	@Schema(description = "솝트스토리 업로드 날짜")
+	private final LocalDateTime uploadedAt;
 
-    @Schema(description = "솝트스토리 업로드 날짜")
-    private final LocalDateTime uploadedAt;
+	@Schema(description = "좋아요 수")
+	private final Integer likeCount;
 
-    @Schema(description = "좋아요 수")
-    private final Integer likeCount;
+	@Schema(description = "현재 사용자 IP가 좋아요를 눌렀는지 여부")
+	private final Boolean isLikedByUser;
 
 }

--- a/src/main/java/sopt/org/homepage/soptstory/entity/SoptStoryLikeEntity.java
+++ b/src/main/java/sopt/org/homepage/soptstory/entity/SoptStoryLikeEntity.java
@@ -23,16 +23,16 @@ public class SoptStoryLikeEntity {
     private Long id;
 
     @Basic
-    @Column(name = "\"sessionId\"", nullable = false, length = 50)
-    private String sessionId;
+    @Column(name = "\"ip\"", nullable = false, length = 45)
+    private String ip;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "\"soptStoryId\"")
     private SoptStoryEntity soptStory;
 
     @Builder
-    public SoptStoryLikeEntity(SoptStoryEntity soptStory, String sessionId) {
+    public SoptStoryLikeEntity(SoptStoryEntity soptStory, String ip) {
         this.soptStory = soptStory;
-        this.sessionId = sessionId;
+        this.ip = ip;
     }
 }

--- a/src/main/java/sopt/org/homepage/soptstory/repository/SoptStoryLikeRepository.java
+++ b/src/main/java/sopt/org/homepage/soptstory/repository/SoptStoryLikeRepository.java
@@ -7,7 +7,7 @@ import sopt.org.homepage.soptstory.entity.SoptStoryEntity;
 import sopt.org.homepage.soptstory.entity.SoptStoryLikeEntity;
 
 public interface SoptStoryLikeRepository extends JpaRepository<SoptStoryLikeEntity, Long> {
-    List<SoptStoryLikeEntity> findAllBySessionIdAndSoptStoryIn(String sessionId, List<SoptStoryEntity> soptStorys);
-    boolean existsBySoptStoryIdAndSessionId(Long soptStoryId, String sessionId);
-    Optional<SoptStoryLikeEntity> findBySoptStoryIdAndSessionId(Long soptStoryId, String sessionId);
+    List<SoptStoryLikeEntity> findAllByIpAndSoptStoryIn(String ip, List<SoptStoryEntity> soptStorys);
+    boolean existsBySoptStoryIdAndIp(Long soptStoryId, String ip);
+    Optional<SoptStoryLikeEntity> findBySoptStoryIdAndIp(Long soptStoryId, String ip);
 }

--- a/src/main/java/sopt/org/homepage/soptstory/service/SoptStoryService.java
+++ b/src/main/java/sopt/org/homepage/soptstory/service/SoptStoryService.java
@@ -12,28 +12,28 @@ public interface SoptStoryService {
      * 솝트 스토리 목록을 페이지네이션하여 조회합니다.
      *
      * @param requestDto 조회 조건 및 페이지네이션 정보
-     * @param sessionId 사용자 세션 ID
+     * @param ip 사용자 IP 주소
      * @return 페이지네이션된 솝트스토리 목록
      */
-    PaginateResponseDto<SoptStoryResponseDto> paginateSoptStorys(GetSoptStoryListRequestDto requestDto, String sessionId);
+    PaginateResponseDto<SoptStoryResponseDto> paginateSoptStorys(GetSoptStoryListRequestDto requestDto, String ip);
 
     /**
      * 솝트스토리에 좋아요를 추가합니다.
      *
      * @param id 솝트스토리 ID
-     * @param session 사용자 세션 ID
+     * @param ip 사용자 IP 주소
      * @return 좋아요 정보
      */
-    LikeSoptStoryResponseDto like(Long id, String session);
+    LikeSoptStoryResponseDto like(Long id, String ip);
 
     /**
      * 솝트 스토리의 좋아요를 취소합니다.
      *
      * @param id 솝트스토리 ID
-     * @param session 사용자 세션 ID
+     * @param ip 사용자 IP 주소
      * @return 좋아요 정보
      */
-    LikeSoptStoryResponseDto unlike(Long id, String session);
+    LikeSoptStoryResponseDto unlike(Long id, String ip);
 
     /**
      * 새로운 솝트스토리를을 생성합니다.


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- #58 

## Work Description ✏️
- 솝트 이야기 좋아요 시,  sessionID 대신 사용자의 IP 로 중복여부 판단되도록 수정
- 솝트 이야기 정보를 불러올때 사용자가 좋아요를 눌렀는지 여부를 클라이언트에서 확인할 수 있도록 필드를 추가하였습니다

