### PR TITLE
infra/fix: Testcontainers 싱글톤 패턴 적용으로 CI 환경 테스트 안정성 개선

### DIFF
--- a/src/test/java/sopt/org/homepage/notification/service/IntegrationTestBase.java
+++ b/src/test/java/sopt/org/homepage/notification/service/IntegrationTestBase.java
@@ -15,17 +15,18 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * - 고전파 스타일 테스트 (Mock 최소화)
  */
 @SpringBootTest
-@Testcontainers
 @ActiveProfiles("test")
-@DirtiesContext
 public abstract class IntegrationTestBase {
 
-    @Container
-    static PostgreSQLContainer<?> postgres =     new PostgreSQLContainer<>("postgres:14.17-alpine")
-            .withDatabaseName("testdb")
-            .withUsername("test")
-            .withPassword("test")
-            .withReuse(true);
+    private static final PostgreSQLContainer<?> postgres;
+
+    static {
+        postgres = new PostgreSQLContainer<>("postgres:14.17-alpine")
+                .withDatabaseName("testdb")
+                .withUsername("test")
+                .withPassword("test");
+        postgres.start();
+    }
 
 
     @DynamicPropertySource


### PR DESCRIPTION
문제 상황:
- GitHub Actions CI 환경에서 NotificationQueryServiceTest의 3개 테스트가 실패
- 로컬 환경에서는 정상 동작하나 CI에서만 Connection refused 에러 발생
- 59개 테스트 중 3개가 "Connection to localhost:32770 refused" 에러로 실패

근본 원인:
@Testcontainers와 @Container 애노테이션 사용 시, 각 테스트 클래스마다 새로운 PostgreSQL 컨테이너가 생성되어 포트가 변경됨 (32769 → 32770 → 32771). 그러나 Spring Test Context는 캐시되어 이전 포트를 계속 참조하여
컨테이너 포트 불일치로 인한 연결 실패가 발생함.

해결 방법:
- @Testcontainers, @Container, @DirtiesContext 애노테이션 제거
- static 초기화 블록에서 PostgreSQL 컨테이너를 명시적으로 시작
- 모든 테스트 클래스가 동일한 컨테이너 인스턴스를 공유하도록 싱글톤 패턴 적용
- 컨테이너가 한 번만 시작되어 포트가 고정되므로 연결 안정성 보장

변경 사항:
- IntegrationTestBase 클래스에서 Testcontainers 자동 생명주기 관리 제거
- PostgreSQL 컨테이너를 static final 필드로 선언하고 static 블록에서 수동 시작
- 불필요한 .withReuse(true) 설정 및 프로파일 중복 설정 제거

효과:
- CI/CD 환경에서 테스트 안정성 확보
- 컨테이너 재시작이 불필요하여 테스트 실행 속도 향상
- 포트 불일치 문제 완전 해결

---
name: Makers PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
---

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- refs #{이슈_번호}

## Work Description ✏️
- 작업 설명을 적어주세요.

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
