### PR TITLE
[FEAT] Lambda 의존성 및 빌드 태스크 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,10 +88,15 @@ dependencies {
 
     // Jsoup for HTML parsing
     implementation 'org.jsoup:jsoup:1.15.4'
-    
+
 
     // Flyway
     implementation 'org.flywaydb:flyway-core:9.22.3'
+
+    // AWS Lambda Dependencies 추가
+    implementation 'com.amazonaws.serverless:aws-serverless-java-container-springboot3:2.1.5'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.4.0'
+    implementation 'com.amazonaws:aws-lambda-java-events:3.16.1'
 
 
     runtimeOnly 'com.h2database:h2'
@@ -113,3 +118,40 @@ def querydslDir = "$buildDir/generated/querydsl"
 sourceSets {
     main.java.srcDir querydslDir
 }
+
+// ============================================
+// Lambda 배포 설정
+// ============================================
+
+// Lambda ZIP 빌드 태스크
+task lambdaJar(type: Zip) {
+    dependsOn jar
+    archiveClassifier = 'lambda'
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    zip64 = true  // 대용량 ZIP 파일 지원
+
+    into('lib') {
+        from(jar)
+        from(configurations.runtimeClasspath) {
+            // Lambda에서 불필요한 파일 제외
+            exclude "org/apache/tomcat/embed/**"
+            exclude "META-INF/*.SF"
+            exclude "META-INF/*.DSA"
+            exclude "META-INF/*.RSA"
+            exclude "META-INF/MANIFEST.MF"
+            exclude "**/module-info.class"
+        }
+    }
+}
+
+// JAR 설정
+jar {
+    enabled = true
+    archiveClassifier = ''
+}
+
+// bootJar는 기존 EC2 배포용으로 유지
+bootJar {
+    enabled = true
+}
+


### PR DESCRIPTION
## 🔗 관련 이슈

Related to #133 

## 📋 작업 내용 요약

AWS Lambda 배포를 위한 의존성 및 Gradle 빌드 태스크를 추가합니다.

### 주요 변경사항

- AWS Serverless Java Container 의존성 추가 (Spring Boot 3 지원)
- aws-lambda-java-core, aws-lambda-java-events 추가
- `lambdaJar` Gradle 태스크 추가

### 추가된 의존성
```groovy
implementation 'com.amazonaws.serverless:aws-serverless-java-container-springboot3:2.1.5'
implementation 'com.amazonaws:aws-lambda-java-core:1.4.0'
implementation 'com.amazonaws:aws-lambda-java-events:3.16.1'
```

### 빌드 명령어

| 용도 | 명령어 | 출력 위치 |
|------|--------|----------|
| EC2 배포 (기존) | `./gradlew bootJar` | build/libs/*.jar |
| Lambda 배포 (신규) | `./gradlew lambdaJar` | build/distributions/*-lambda.zip |

## 🧪 테스트

- [x] `./gradlew bootJar` 정상 동작 (기존 EC2 배포 영향 없음)
<img width="796" height="295" alt="image" src="https://github.com/user-attachments/assets/38b14022-5201-4a7c-9fdd-d56a3d298366" />

- [x] `./gradlew lambdaJar` 정상 동작
<img width="707" height="310" alt="image" src="https://github.com/user-attachments/assets/ca49a965-6c1d-4a6b-85a2-40ec551419b4" />

- [x] Lambda ZIP 파일 생성 확인

## ⚠️ 주의사항

- [x] Breaking Change 없음
- [x] 기존 CI/CD 파이프라인 영향 없음