### PR TITLE
 [FIX] Lambda 환경 Swagger UI 동작 오류 및 API 404 에러 해결

### DIFF
--- a/src/main/java/sopt/org/homepage/LambdaHandler.java
+++ b/src/main/java/sopt/org/homepage/LambdaHandler.java
@@ -22,7 +22,8 @@ public class LambdaHandler implements RequestStreamHandler {
         try {
             handler = SpringBootLambdaContainerHandler
                     .getAwsProxyHandler(HomepageApplication.class);
-
+            handler.getContainerConfig().setStripBasePath(true);
+            handler.getContainerConfig().setServiceBasePath("/v2");
             // Binary Content Type 등록 (Swagger UI 이미지, 파일 다운로드 등)
             SpringBootLambdaContainerHandler.getContainerConfig().addBinaryContentTypes(
                     "image/png",

--- a/src/main/resources/application-lambda-dev.yml
+++ b/src/main/resources/application-lambda-dev.yml
@@ -59,21 +59,30 @@ spring:
 # ============================================
 # Swagger/OpenAPI
 # ============================================
+#springdoc:
+#  swagger-ui:
+#    path: /api-docs
+#    operations-sorter: alpha
+#  api-docs:
+#    path: /api-docs
+#    groups:
+#      enabled: true
+
 springdoc:
   swagger-ui:
-    path: /api-docs
-    operations-sorter: alpha
+    path: /swagger-ui.html
+    url: /v3/api-docs                    # ✨ /dev 제거됨
+    config-url: /v3/api-docs/swagger-config  # ✨ /dev 제거됨
   api-docs:
-    path: /api-docs
-    groups:
-      enabled: true
+    path: /v3/api-docs
+
 
 # ============================================
 # 서버 설정
 # ============================================
 server:
   servlet:
-    context-path:  # Lambda에서는 context-path 제거 (API Gateway stage와 충돌 방지)
+    #context-path: /v2              # ✨ 이거 추가!
     encoding:
       charset: UTF-8
       force: true


### PR DESCRIPTION
## Related Issue 🚀
- related to #169  

## 📋 변경 사항 요약

Lambda 환경에서 발생하던 **API 404 오류** 및 **Swagger UI 렌더링 문제**를 해결했습니다.

### 주요 변경 사항

| 구분 | 파일 | 변경 내용 |
|------|------|----------|
| ✏️ 수정 | `LambdaHandler.java` | Base Path Strip 설정 + Binary Content Type 등록 |
| ✏️ 수정 | `application-lambda-dev.yml` | context-path 제거, Swagger 경로 수정, UTF-8 인코딩 설정 |

---

## 🔍 문제 원인

### 문제 1: 모든 API가 404 반환

**EC2 vs Lambda 환경 차이**

```
┌─────────────────────────────────────────────────────────────────────────────┐
│                         환경별 context-path 처리 방식                        │
├─────────────────────────────────────────────────────────────────────────────┤
│                                                                             │
│   EC2 (Tomcat 있음)                    Lambda (Tomcat 없음)                 │
│   ─────────────────                    ──────────────────                   │
│                                                                             │
│   server.servlet.                      server.servlet.                      │
│   context-path: /v2                    context-path: /v2                    │
│        ↓                                    ↓                               │
│   Tomcat이 /v2 처리 ✅                 설정 무시됨 ❌                        │
│        ↓                                    ↓                               │
│   /v2/homepage → /homepage             /v2/homepage → /v2/homepage          │
│        ↓                                    ↓                               │
│   Controller 매칭 ✅                   404 Not Found ❌                     │
│                                                                             │
└─────────────────────────────────────────────────────────────────────────────┘
```

**원인**: Lambda에는 Embedded Tomcat이 없어 `server.servlet.context-path` 설정이 무시됨

**잘못된 시도**: `setServiceBasePath` 단독 사용

```
요청: /v2/homepage
      ↓
setServiceBasePath("/v2")가 /v2를 추가 (strip이 아닌 prefix!)
      ↓
결과: /v2/v2/homepage → 404
```

---

### 문제 2: Swagger UI 이미지 깨짐

**API Gateway + Lambda의 바이너리 응답 처리**

```
┌─────────────────────────────────────────────────────────────────────────────┐
│                         문제 상황 (수정 전)                                   │
├─────────────────────────────────────────────────────────────────────────────┤
│                                                                             │
│   Swagger UI 요청                                                           │
│       │                                                                     │
│       ├── /swagger-ui/index.html          → text/html       ✅ 정상        │
│       ├── /swagger-ui/swagger-ui.css      → text/css        ✅ 정상        │
│       │                                                                     │
│       ├── /swagger-ui/favicon-32x32.png   → image/png       ❌ 깨짐        │
│       └── 기타 이미지 리소스               → image/*         ❌ 깨짐        │
│                                                                             │
│   원인: Binary Content Type 미등록 → 이미지가 텍스트로 처리되어 깨짐         │
│                                                                             │
└─────────────────────────────────────────────────────────────────────────────┘
```

**원인**:
- API Gateway는 기본적으로 **텍스트 응답**만 처리
- **바이너리 응답**(이미지 등)은 명시적으로 등록해야 Base64 인코딩되어 정상 전달
- Swagger UI는 favicon, 로고 등 **이미지 리소스**를 포함하므로 등록 필요

---

## 🔧 구현 세부 내용

### 1. LambdaHandler.java 수정

```java
static {
    try {
        handler = SpringBootLambdaContainerHandler
                .getAwsProxyHandler(HomepageApplication.class);

        // ========================================
        // [해결 1] Lambda에서 /v2 prefix 제거 설정
        // ========================================
        handler.getContainerConfig().setStripBasePath(true);    // strip 기능 ON
        handler.getContainerConfig().setServiceBasePath("/v2"); // strip할 경로

        // ========================================
        // [해결 2] Binary Content Type 등록 (Swagger UI 이미지, 파일 다운로드 등)
        // ========================================
        SpringBootLambdaContainerHandler.getContainerConfig().addBinaryContentTypes(
                "image/png",
                "image/jpeg",
                "image/gif",
                "image/webp",
                "image/svg+xml",
                "image/x-icon",
                "application/octet-stream"
        );

    } catch (ContainerInitializationException e) {
        throw new RuntimeException("Spring Boot 애플리케이션 초기화 실패", e);
    }
}
```

**Base Path 설정 조합의 의미:**

| 설정 | 역할 |
|------|------|
| `setStripBasePath(true)` | Base path stripping 기능 활성화 |
| `setServiceBasePath("/v2")` | /v2를 strip 대상으로 지정 |

**등록된 Binary Content-Type:**

| Content-Type | 용도 |
|--------------|------|
| `image/png` | PNG 이미지 (favicon 등) |
| `image/jpeg` | JPEG 이미지 |
| `image/gif` | GIF 이미지 |
| `image/webp` | WebP 이미지 |
| `image/svg+xml` | SVG 이미지 |
| `image/x-icon` | Favicon (.ico) |
| `application/octet-stream` | 바이너리 파일 다운로드 |

---

### 2. application-lambda-dev.yml 수정

```yaml
springdoc:
  swagger-ui:
    path: /swagger-ui.html
    url: /v3/api-docs                    # API Gateway stage 없이 설정
    config-url: /v3/api-docs/swagger-config
  api-docs:
    path: /v3/api-docs

server:
  servlet:
    # context-path: /v2  # ❌ Lambda에서는 LambdaHandler에서 처리
    encoding:
      charset: UTF-8
      force: true
      enabled: true
```

**변경 포인트:**
- `context-path` 제거: Lambda에서는 LambdaHandler에서 경로 처리
- Swagger 경로 설정: API Gateway stage 없이 설정
- UTF-8 인코딩: 한글, 특수문자 등이 포함된 API 문서 설명 정상 표시

---

## 📊 수정 후 동작 흐름

### API 요청 처리 흐름

```
┌─────────────────────────────────────────────────────────────────────────────┐
│                              API 요청 처리 흐름                              │
├─────────────────────────────────────────────────────────────────────────────┤
│                                                                             │
│   1. 클라이언트 요청: GET /v2/homepage                                      │
│                          ↓                                                  │
│   2. API Gateway → Lambda 전달                                              │
│                          ↓                                                  │
│   3. LambdaHandler 처리:                                                    │
│      ┌────────────────────────────────────────────────────────────────┐    │
│      │  setStripBasePath(true) + setServiceBasePath("/v2")            │    │
│      │                                                                 │    │
│      │  입력: /v2/homepage                                             │    │
│      │  처리: /v2 제거 (strip)                                         │    │
│      │  출력: /homepage                                                │    │
│      └────────────────────────────────────────────────────────────────┘    │
│                          ↓                                                  │
│   4. Spring DispatcherServlet: /homepage                                    │
│                          ↓                                                  │
│   5. @RequestMapping("homepage") 매칭 ✅                                    │
│                          ↓                                                  │
│   6. HTTP 200 OK 응답                                                       │
│                                                                             │
└─────────────────────────────────────────────────────────────────────────────┘
```

### 이미지 요청 처리 흐름

```
┌─────────────────────────────────────────────────────────────────────────────┐
│                    Binary Content Type 등록 후 흐름                          │
├─────────────────────────────────────────────────────────────────────────────┤
│                                                                             │
│   1. Swagger UI 이미지 요청                                                  │
│      GET /swagger-ui/favicon-32x32.png                                      │
│                      ↓                                                      │
│   2. Lambda 응답 생성                                                        │
│      Content-Type: image/png                                                │
│      Body: [PNG 바이너리 데이터]                                             │
│                      ↓                                                      │
│   3. SpringBootLambdaContainerHandler 처리                                  │
│      - binaryContentTypes.contains("image/png") → true                     │
│      - response.setBase64Encoded(true) ✅                                  │
│                      ↓                                                      │
│   4. API Gateway                                                            │
│      - isBase64Encoded: true 확인                                           │
│      - Base64 디코딩하여 바이너리로 전달                                     │
│                      ↓                                                      │
│   5. 브라우저에서 이미지 정상 표시 ✅                                         │
│                                                                             │
└─────────────────────────────────────────────────────────────────────────────┘
```

---

## 🧪 테스트 방법

### API 테스트

```bash
# Health Check
curl -v https://org-api-dev.sopt.org/v2/health
# Expected: HTTP 200 OK

# Homepage API
curl -v https://org-api-dev.sopt.org/v2/homepage
# Expected: HTTP 200 OK with JSON response

# About 페이지
curl -v https://org-api-dev.sopt.org/v2/homepage/about

# Recruit 페이지
curl -v https://org-api-dev.sopt.org/v2/homepage/recruit
```

### Swagger UI 테스트

```bash
# 브라우저에서 접속
https://org-api-dev.sopt.org/v2/swagger-ui/index.html

# Swagger UI 메인 페이지
curl -v https://org-api-dev.sopt.org/v2/swagger-ui/index.html

# API 문서 JSON
curl -v https://org-api-dev.sopt.org/v2/api-docs

# Favicon (이미지) - Binary Content Type 테스트
curl -s -o favicon.png https://org-api-dev.sopt.org/v2/swagger-ui/favicon-32x32.png
file favicon.png  # PNG image data 확인
```

### CloudWatch 로그 확인

```bash
aws logs tail /aws/lambda/sopt-org-spring-dev-api --follow --profile team-org
```

**정상 로그 예시:**
```
"GET /v2/homepage HTTP/1.1" 200 - "-" "curl/8.7.1" combined
```

---

## 📸 테스트 결과

### 수정 전
- ❌ 모든 API 404 반환
- ❌ CloudWatch: `"GET /v2/v2/homepage HTTP/1.1" 404` (경로 중복 문제)
- ❌ Swagger UI 빈 화면 표시
- ❌ 이미지 리소스 로딩 실패

### 수정 후
- ✅ API 정상 응답 (200 OK)
- ✅ CloudWatch: `"GET /v2/homepage HTTP/1.1" 200`
- ✅ Swagger UI 정상 렌더링
- ✅ 이미지 리소스 정상 로딩
- ✅ API 문서 한글 설명 정상 표시

(스크린샷 첨부)

---

## ✅ 체크리스트

### 코드 품질
- [ ] `setStripBasePath(true)` 설정 추가
- [ ] `setServiceBasePath("/v2")` 설정 추가
- [ ] Binary Content Type 등록
- [ ] `application-lambda-dev.yml` context-path 제거
- [ ] Swagger 경로 설정 업데이트
- [ ] UTF-8 인코딩 설정 추가
- [ ] 기존 EC2 환경 영향 없음

### 테스트
- [ ] Lambda 재배포 완료
- [ ] `/v2/health` API 정상 응답 확인
- [ ] `/v2/homepage` API 정상 응답 확인
- [ ] Swagger UI 페이지 접속 테스트
- [ ] Swagger UI 이미지 리소스 로딩 확인
- [ ] API 문서 한글 설명 정상 표시 확인
- [ ] Try it out 기능 정상 동작 확인
- [ ] 인증 필요 API 테스트

---

## 📝 핵심 교훈

### Lambda 환경에서 경로 처리 시 주의사항

| 주의사항 | 설명 |
|---------|------|
| **Tomcat 부재** | Lambda에는 Embedded Tomcat이 없어 `server.servlet.context-path` 무시됨 |
| **설정 조합 필수** | `setStripBasePath(true)` + `setServiceBasePath("/v2")` 반드시 함께 사용 |
| **CloudWatch 확인** | 실제 Lambda가 받는 경로를 로그로 확인하여 디버깅 |

### 설정별 동작 비교

| 설정 | 결과 |
|------|------|
| `setServiceBasePath("/v2")` 단독 | `/v2/v2/homepage` (중복) ❌ |
| `context-path: /v2` (yml) | 무시됨, `/v2/homepage` 그대로 전달 ❌ |
| `setStripBasePath(true)` + `setServiceBasePath("/v2")` | `/homepage` ✅ |

### Binary Content Type 관련

- 이 설정은 **Swagger UI뿐만 아니라 모든 이미지 응답**에 적용됩니다
- S3 Presigned URL로 업로드한 이미지 조회에도 영향
- EC2 환경에는 영향 없음 (Lambda 전용 설정)

---

## 🔗 참고 자료

- [AWS Serverless Java Container Wiki](https://github.com/awslabs/aws-serverless-java-container/wiki)
- [Spring Boot 3 Quick Start](https://github.com/awslabs/aws-serverless-java-container/wiki/Quick-start---Spring-Boot3)