### PR TITLE
[FIX] prod Flyway 마이그레이션 실패 해결

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,4 +1,7 @@
 spring:
+  flyway:
+    baseline-on-migrate: true
+    baseline-version: 2
   config:
     activate:
       on-profile: prod


### PR DESCRIPTION
## 🔗 관련 이슈

Related to #이슈번호

## 📋 작업 내용 요약

### 주요 변경사항
- Flyway baseline 설정 추가하여 기존 DB 상태 인식하도록 수정

## 💡 구현 방법

prod DB에 `flyway_schema_history` 테이블이 없어서 V1 마이그레이션을 재실행하려다 실패하는 문제.
`baseline-on-migrate: true`와 `baseline-version: 2` 설정을 추가하여 현재 DB 상태를 V2 완료 상태로 인식하도록 함.

## 🧪 테스트

### 테스트 케이스

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 추가/수정
- [x] 수동 테스트 완료

### 테스트 시나리오

1. prod 환경에 배포
2. 애플리케이션 정상 시작 확인
3. `flyway_schema_history` 테이블 생성 및 baseline 기록 확인

## 🔍 리뷰 포인트

- baseline-version이 현재 마이그레이션 파일 개수(2)와 일치하는지 확인

## ⚠️ 주의사항

- [x] Breaking Change 없음
- [ ] DB 마이그레이션 필요 (있다면 설명)
- [x] 환경 변수 추가/변경: Flyway baseline 설정 추가
- [ ] 의존성 추가/변경 (있다면 설명)

---

## ✅ PR 체크리스트

- [x] 코드 스타일 가이드 준수
- [x] Self Review 완료
- [ ] 테스트 코드 작성 및 통과
- [ ] 문서 업데이트 (필요 시)
- [x] 커밋 메시지 컨벤션 준수
- [x] 충돌(Conflict) 해결 완료
```
