### PR TITLE
[FEAT] credential 설정 추가

### DIFF
--- a/.github/workflows/cd.develop.yml
+++ b/.github/workflows/cd.develop.yml
@@ -29,48 +29,62 @@ jobs:
           docker push public.ecr.aws/${{ secrets.AWS_ACCOUNT_ID }}/${{ secrets.DEV_ECR_REPO }}:latest
 
   # CD: EC2 배포
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
+deploy:
+  needs: build
+  runs-on: ubuntu-latest
 
-    steps:
-      - name: Deploy to EC2
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.HOST }}
-          username: ec2-user
-          key: ${{ secrets.DEV_PEM_KEY }}
-          script: |
-            # Parameter Store에서 .env 생성
-            aws ssm get-parameters-by-path \
-              --path "/sopt/dev/" \
-              --recursive \
-              --with-decryption \
-              --query "Parameters[*].[Name,Value]" \
-              --output text \
-              --region ap-northeast-2 | while read name value; do
-                key=$(echo $name | awk -F'/' '{print $NF}')
-                echo "${key}=${value}"
-            done > /tmp/.env
+  steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
+        aws-region: ap-northeast-2
 
-            # 파라미터 로드 확인
-            PARAM_COUNT=$(wc -l < /tmp/.env)
-            echo "✅ ${PARAM_COUNT}개 파라미터 로드 완료"
+    - name: Fetch env from Parameter Store
+      run: |
+        aws ssm get-parameters-by-path \
+          --path "/sopt/dev/" \
+          --recursive \
+          --with-decryption \
+          --query "Parameters[*].[Name,Value]" \
+          --output text | while read name value; do
+            key=$(echo $name | awk -F'/' '{print $NF}')
+            echo "${key}=${value}"
+        done > /tmp/.env
+        
+        PARAM_COUNT=$(wc -l < /tmp/.env)
+        echo "✅ ${PARAM_COUNT}개 파라미터 로드 완료"
+        
+        if [ "$PARAM_COUNT" -lt 5 ]; then
+          echo "❌ 파라미터가 너무 적습니다. 배포를 중단합니다."
+          rm -f /tmp/.env
+          exit 1
+        fi
 
-            if [ "$PARAM_COUNT" -lt 5 ]; then
-              echo "❌ 파라미터가 너무 적습니다. 배포를 중단합니다."
-              rm -f /tmp/.env
-              exit 1
-            fi
+    - name: Copy .env to EC2
+      uses: appleboy/scp-action@master
+      with:
+        host: ${{ secrets.HOST }}
+        username: ec2-user
+        key: ${{ secrets.DEV_PEM_KEY }}
+        source: "/tmp/.env"
+        target: "/tmp/"
 
-            sudo docker stop spring-dev-server || true
-            sudo docker rm spring-dev-server || true
-            sudo docker image prune -a -f
-            sudo docker pull public.ecr.aws/${{ secrets.AWS_ACCOUNT_ID }}/${{ secrets.DEV_ECR_REPO }}:latest
-            sudo docker run --name spring-dev-server \
-              --env-file /tmp/.env \
-              -d -p 8086:8080 -t \
-              public.ecr.aws/${{ secrets.AWS_ACCOUNT_ID }}/${{ secrets.DEV_ECR_REPO }}:latest
-
-            # 임시 파일 삭제
-            rm -f /tmp/.env
+    - name: Deploy to EC2
+      uses: appleboy/ssh-action@master
+      with:
+        host: ${{ secrets.HOST }}
+        username: ec2-user
+        key: ${{ secrets.DEV_PEM_KEY }}
+        script: |
+          sudo docker stop spring-dev-server || true
+          sudo docker rm spring-dev-server || true
+          sudo docker image prune -a -f
+          sudo docker pull public.ecr.aws/${{ secrets.AWS_ACCOUNT_ID }}/${{ secrets.DEV_ECR_REPO }}:latest
+          sudo docker run --name spring-dev-server \
+            --env-file /tmp/.env \
+            -d -p 8086:8080 -t \
+            public.ecr.aws/${{ secrets.AWS_ACCOUNT_ID }}/${{ secrets.DEV_ECR_REPO }}:latest
+          
+          rm -f /tmp/.env


### PR DESCRIPTION
## 🔗 관련 이슈

Related to #<이슈번호>

## 📋 작업 내용 요약

EC2 배포 워크플로우의 SSM 호출 주체를 EC2 인스턴스에서 GitHub Actions 러너로 변경

### 주요 변경사항
- `cd.develop.yml`: SSM 호출을 GitHub Actions 러너에서 수행 후 SCP로 EC2에 `.env` 전송하도록 변경
- `cd.production.yml`: 동일 패턴 적용 및 deploy job 인덴트 오류 수정

## 💡 구현 방법

EC2 인스턴스에 `team-crew` 계정의 AWS credential이 설정되어 있어 `team-org`의 SSM 권한으로 호출이 불가한 문제가 있었습니다. EC2의 credential을 변경하면 다른 팀에 영향을 줄 수 있어, 호출 주체를 GitHub Actions 러너로 변경했습니다.

**변경 전:** EC2 SSH 접속 → EC2에서 SSM 호출 → `.env` 생성 → Docker 실행 (단일 step)

**변경 후:** GitHub Actions 러너에서 SSM 호출 → `.env` 생성 → SCP로 EC2 전송 → SSH로 Docker 실행 (3 step)

이 방식은 EC2에 어떤 AWS credential이 설정되어 있든 영향을 받지 않고, 다른 팀의 설정을 건드리지 않습니다.

## 🧪 테스트

### 테스트 케이스

- [ ] 수동 테스트 완료

### 테스트 시나리오

1. Dev 환경 `workflow_dispatch`로 수동 배포 → GitHub Actions 로그에서 파라미터 로드 성공 확인
2. Dev 서버 API 정상 응답 확인
3. Prod 환경 동일 검증

## 🔍 리뷰 포인트

- SCP로 전송 시 `/tmp/.env` 경로가 EC2에서 정상적으로 접근 가능한지
- GitHub Actions 러너에서 생성한 `.env`가 SCP 전송 후 EC2에서 동일한 경로(`/tmp/.env`)에 위치하는지

## ⚠️ 주의사항

- [x] Breaking Change 없음
- [ ] DB 마이그레이션 필요
- [ ] 환경 변수 추가/변경
- [ ] 의존성 추가/변경

**이전 PR 대비 변경점:** EC2에서 직접 SSM을 호출하는 방식에서 AccessDeniedException 발생 (`team-crew` 계정 권한 문제). GitHub Actions 러너 기반으로 전환하여 해결.

## 📝 추가 메모

- EC2의 AWS credential 설정 현황: dev EC2에 `team-crew` 계정이 설정되어 있음
- `appleboy/scp-action@master`를 새로 사용합니다

---

## ✅ PR 체크리스트

- [ ] 코드 스타일 가이드 준수
- [ ] Self Review 완료
- [ ] 테스트 코드 작성 및 통과
- [ ] 문서 업데이트 (필요 시)
- [ ] 커밋 메시지 컨벤션 준수
- [ ] 충돌(Conflict) 해결 완료
```

커밋 메시지:
```
fix: SSM 호출 주체를 GitHub Actions 러너로 변경

- EC2에 설정된 team-crew credential로 인한 AccessDeniedException 해결
- GitHub Actions 러너에서 SSM 호출 후 SCP로 .env 전송 방식으로 변경
- cd.production.yml deploy job 인덴트 오류 수정

Refs #<이슈번호>