### PR TITLE
[REFACTOR]   PlaygroundServiceImpl 책임 분리 및 가독성 개선

### DIFF
--- a/src/main/java/sopt/org/homepage/infrastructure/external/playground/InternalController.java
+++ b/src/main/java/sopt/org/homepage/infrastructure/external/playground/InternalController.java
@@ -14,6 +14,9 @@ import sopt.org.homepage.global.config.AuthConfig;
 import sopt.org.homepage.global.exception.BusinessLogicException;
 import sopt.org.homepage.infrastructure.external.playground.dto.request.ScrapLinkRequestDto;
 import sopt.org.homepage.infrastructure.external.playground.dto.response.ScrapLinkResponseDto;
+import sopt.org.homepage.infrastructure.external.scrap.dto.CreateScraperResponseDto;
+import sopt.org.homepage.infrastructure.external.scrap.dto.ScrapArticleDto;
+import sopt.org.homepage.infrastructure.external.scrap.service.ScraperService;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,7 +24,7 @@ import sopt.org.homepage.infrastructure.external.playground.dto.response.ScrapLi
 @Tag(name = "Internal")
 public class InternalController {
 
-    private final PlaygroundService playgroundService;
+    private final ScraperService scraperService;
     private final AuthConfig authConfig;
 
     @PostMapping("scrap")
@@ -38,9 +41,18 @@ public class InternalController {
             throw new BusinessLogicException("api-key is invalid");
         }
 
-        return ResponseEntity.ok(playgroundService.scrapLink(dto));
+        CreateScraperResponseDto scrapResult = scraperService.scrap(
+                new ScrapArticleDto(dto.getLink())
+        );
+
+        return ResponseEntity.ok(
+                ScrapLinkResponseDto.builder()
+                        .thumbnailUrl(scrapResult.getThumbnailUrl())
+                        .title(scrapResult.getTitle())
+                        .description(scrapResult.getDescription())
+                        .url(scrapResult.getArticleUrl())
+                        .build()
+        );
     }
-
 }
-
 

--- a/src/main/java/sopt/org/homepage/infrastructure/external/playground/PlaygroundService.java
+++ b/src/main/java/sopt/org/homepage/infrastructure/external/playground/PlaygroundService.java
@@ -1,9 +1,6 @@
 package sopt.org.homepage.infrastructure.external.playground;
 
 import java.util.List;
-import sopt.org.homepage.infrastructure.external.playground.dto.PlaygroundProjectResponseDto;
-import sopt.org.homepage.infrastructure.external.playground.dto.request.ScrapLinkRequestDto;
-import sopt.org.homepage.infrastructure.external.playground.dto.response.ScrapLinkResponseDto;
 import sopt.org.homepage.project.dto.request.GetProjectsRequestDto;
 import sopt.org.homepage.project.dto.response.ProjectDetailResponseDto;
 import sopt.org.homepage.project.dto.response.ProjectsResponseDto;
@@ -11,9 +8,6 @@ import sopt.org.homepage.project.dto.response.ProjectsResponseDto;
 public interface PlaygroundService {
     List<ProjectsResponseDto> getAllProjects(GetProjectsRequestDto projectRequest);
 
-    List<PlaygroundProjectResponseDto> getProjectsWithPagination();
-
     ProjectDetailResponseDto getProjectDetail(Long projectId);
 
-    ScrapLinkResponseDto scrapLink(ScrapLinkRequestDto scrapLinkRequestDto);
 }

--- a/src/main/java/sopt/org/homepage/infrastructure/external/playground/PlaygroundServiceImpl.java
+++ b/src/main/java/sopt/org/homepage/infrastructure/external/playground/PlaygroundServiceImpl.java
@@ -14,15 +14,13 @@ import sopt.org.homepage.global.common.util.ArrayUtil;
 import sopt.org.homepage.global.config.AuthConfig;
 import sopt.org.homepage.infrastructure.cache.CacheService;
 import sopt.org.homepage.infrastructure.external.playground.dto.PlaygroundProjectAxiosResponseDto;
+import sopt.org.homepage.infrastructure.external.playground.dto.PlaygroundProjectDetailResponse;
 import sopt.org.homepage.infrastructure.external.playground.dto.PlaygroundProjectResponseDto;
-import sopt.org.homepage.infrastructure.external.playground.dto.request.ScrapLinkRequestDto;
-import sopt.org.homepage.infrastructure.external.playground.dto.response.ScrapLinkResponseDto;
-import sopt.org.homepage.infrastructure.external.scrap.dto.CreateScraperResponseDto;
-import sopt.org.homepage.infrastructure.external.scrap.dto.ScrapArticleDto;
-import sopt.org.homepage.infrastructure.external.scrap.service.ScraperService;
 import sopt.org.homepage.project.dto.request.GetProjectsRequestDto;
 import sopt.org.homepage.project.dto.response.ProjectDetailResponseDto;
 import sopt.org.homepage.project.dto.response.ProjectsResponseDto;
+import sopt.org.homepage.project.dto.type.ProjectType;
+import sopt.org.homepage.project.dto.type.ServiceType;
 
 @Slf4j
 @Service
@@ -34,64 +32,54 @@ public class PlaygroundServiceImpl implements PlaygroundService {
     private final ArrayUtil arrayUtil;
     private final CacheService cacheService;
     private static final String PROJECT_CACHE_KEY = "all_projects";
-    private final ScraperService scraperService;
 
 
     @Override
     public List<ProjectsResponseDto> getAllProjects(GetProjectsRequestDto projectRequest) {
-        List<PlaygroundProjectResponseDto> projectListResponse = cacheService.get(
-                CacheType.PROJECT_LIST, PROJECT_CACHE_KEY, new TypeReference<>() {
-                }
-        );
-
-        if (projectListResponse == null) {
-            try {
-                projectListResponse = getProjectsWithPagination();
-                cacheService.put(CacheType.PROJECT_LIST, PROJECT_CACHE_KEY, projectListResponse);
-            } catch (Exception e) {
-                log.error("Project API Failed to fetch projects", e);
-                return Collections.emptyList();
-            }
-        }
-
-        List<ProjectsResponseDto> result = new ArrayList<>();
-        var filter = projectRequest.getFilter();
-        var platform = projectRequest.getPlatform();
-
-        var uniqueResponse = arrayUtil.dropDuplication(projectListResponse, PlaygroundProjectResponseDto::name);
-        var uniqueLinkResponse = uniqueResponse.stream()
-                .map(response -> response.ProjectWithLink(
-                        response.links() != null ?
-                                arrayUtil.dropDuplication(response.links(),
-                                        PlaygroundProjectResponseDto.ProjectLinkResponse::linkId) :
-                                Collections.emptyList()
-                ))
-                .toList();
-
-        if (uniqueLinkResponse.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        for (var data : projectListResponse) {
-            result.add(responseMapper.toProjectResponse(data));
-        }
-
-        if (filter != null) {
-            result = result.stream()
-                    .filter(element -> element.getCategory().project().equals(filter))
-                    .collect(Collectors.toList());
-        }
-        if (platform != null) {
-            result = result.stream()
-                    .filter(element -> element.getServiceType().contains(platform))
-                    .collect(Collectors.toList());
-        }
-
-        return result;
+        List<PlaygroundProjectResponseDto> rawProjects = fetchProjectsWithCache();
+        List<ProjectsResponseDto> projects = convertToResponseDto(rawProjects);
+        return applyFilters(projects, projectRequest.getFilter(), projectRequest.getPlatform());
     }
 
     @Override
-    public List<PlaygroundProjectResponseDto> getProjectsWithPagination() {
+    public ProjectDetailResponseDto getProjectDetail(Long projectId) {
+        PlaygroundProjectDetailResponse projectResponse = playgroundClient.getProjectDetail(
+                authConfig.getPlaygroundToken(), projectId
+        );
+        if (projectResponse == null) {
+            throw new RuntimeException("프로젝트 데이터를 가져오지 못했습니다.");
+        }
+        return responseMapper.toProjectDetailResponse(projectResponse);
+    }
+
+    // ===== Private Methods =====
+
+    /**
+     * 캐시에서 프로젝트 목록 조회, 없으면 API 호출 후 캐시 저장
+     */
+    private List<PlaygroundProjectResponseDto> fetchProjectsWithCache() {
+        List<PlaygroundProjectResponseDto> cached = cacheService.get(
+                CacheType.PROJECT_LIST, PROJECT_CACHE_KEY, new TypeReference<>() {
+                }
+        );
+        if (cached != null) {
+            return cached;
+        }
+
+        try {
+            List<PlaygroundProjectResponseDto> fetched = fetchAllFromApi();
+            cacheService.put(CacheType.PROJECT_LIST, PROJECT_CACHE_KEY, fetched);
+            return fetched;
+        } catch (Exception e) {
+            log.error("Failed to fetch projects from Playground API", e);
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Playground API에서 커서 기반 페이지네이션으로 전체 프로젝트 조회
+     */
+    private List<PlaygroundProjectResponseDto> fetchAllFromApi() {
         final int limit = 20;
         int cursor = 0;
         int totalCount = 10;
@@ -99,8 +87,7 @@ public class PlaygroundServiceImpl implements PlaygroundService {
 
         for (int i = 0; i < totalCount + 1; i = i + limit) {
             PlaygroundProjectAxiosResponseDto projectData = playgroundClient.getAllProjects(
-                    limit,
-                    cursor
+                    limit, cursor
             );
 
             if (projectData.projectList().isEmpty()) {
@@ -121,27 +108,44 @@ public class PlaygroundServiceImpl implements PlaygroundService {
         return response;
     }
 
-    @Override
-    public ProjectDetailResponseDto getProjectDetail(Long projectId) {
-        var projectResponse = playgroundClient.getProjectDetail(authConfig.getPlaygroundToken(), projectId);
-        if (projectResponse == null) {
-            throw new RuntimeException("프로젝트 데이터를 가져오지 못했습니다.");
-        }
+    /**
+     * Playground 원시 데이터 → 응답 DTO 변환 (중복 제거 포함)
+     */
+    private List<ProjectsResponseDto> convertToResponseDto(
+            List<PlaygroundProjectResponseDto> rawProjects) {
+        List<PlaygroundProjectResponseDto> uniqueProjects = arrayUtil.dropDuplication(
+                rawProjects, PlaygroundProjectResponseDto::name
+        );
 
-        return responseMapper.toProjectDetailResponse(projectResponse);
+        return uniqueProjects.stream()
+                .map(project -> responseMapper.toProjectResponse(
+                        project.ProjectWithLink(
+                                project.links() != null
+                                        ? arrayUtil.dropDuplication(project.links(),
+                                        PlaygroundProjectResponseDto.ProjectLinkResponse::linkId)
+                                        : Collections.emptyList()
+                        )
+                ))
+                .collect(Collectors.toList());
     }
 
-
-    @Override
-    public ScrapLinkResponseDto scrapLink(ScrapLinkRequestDto dto) {
-
-        CreateScraperResponseDto scrapResult = scraperService.scrap(new ScrapArticleDto(dto.getLink()));
-
-        return ScrapLinkResponseDto.builder()
-                .thumbnailUrl(scrapResult.getThumbnailUrl())
-                .title(scrapResult.getTitle())
-                .description(scrapResult.getDescription())
-                .url(scrapResult.getArticleUrl())
-                .build();
+    /**
+     * 카테고리, 플랫폼 필터 적용
+     */
+    private List<ProjectsResponseDto> applyFilters(
+            List<ProjectsResponseDto> projects,
+            ProjectType filter,
+            ServiceType platform) {
+        if (filter != null) {
+            projects = projects.stream()
+                    .filter(p -> p.getCategory().project().equals(filter))
+                    .collect(Collectors.toList());
+        }
+        if (platform != null) {
+            projects = projects.stream()
+                    .filter(p -> p.getServiceType().contains(platform))
+                    .collect(Collectors.toList());
+        }
+        return projects;
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

Related to #146 

## 📋 작업 내용 요약

`PlaygroundServiceImpl`의 책임을 분리하고 `getAllProjects` 가독성을 개선했습니다.

### 주요 변경사항
- `scrapLink`을 `PlaygroundService`에서 제거, `InternalController`에서 `ScraperService` 직접 호출
- `getAllProjects` 40줄 → 3줄, 단계별 private 메서드로 분리 (`fetchProjectsWithCache` → `convertToResponseDto` → `applyFilters`)
- 중복 제거 후 원본 리스트로 DTO 변환하던 버그 수정
- `getProjectsWithPagination` → `private fetchAllFromApi`로 접근 제어 변경

## 💡 구현 방법

**scrapLink 분리 근거:**
- `PlaygroundServiceImpl.scrapLink()`은 Playground API를 전혀 호출하지 않고 `ScraperService`만 래핑
- `ReviewCommandController`, `SoptStoryCommandController`에서 이미 `ScraperService`를 직접 주입하는 패턴 사용 중
- `InternalController`도 동일 패턴으로 통일

**getAllProjects 버그 수정:**
```java
// Before: 중복 제거한 uniqueResponse를 만들어놓고 원본으로 변환 ⚠️
var uniqueResponse = arrayUtil.dropDuplication(projectListResponse, ...);
for (var data : projectListResponse) {  // ← uniqueResponse가 아닌 원본!
    result.add(responseMapper.toProjectResponse(data));
}

// After: 중복 제거된 리스트로 변환 ✅
List<PlaygroundProjectResponseDto> uniqueProjects = arrayUtil.dropDuplication(...);
return uniqueProjects.stream()
        .map(project -> responseMapper.toProjectResponse(...))
        .collect(Collectors.toList());
```

## 🧪 테스트

### 테스트 케이스

- [ ] 수동 테스트 완료

### 테스트 시나리오

1. `GET /projects` - 프로젝트 목록 정상 조회, 중복 데이터 제거 확인
2. `GET /projects/{projectId}` - 단건 조회 정상 동작
3. `POST /internal/scrap` - 블로그 링크 스크래핑 정상 동작
4. `GET /homepage` - Main 페이지 프로젝트 수 정상 조회
5. `GET /homepage/about` - 회원 목록 정상 조회

## 🔍 리뷰 포인트

- 중복 제거 버그 수정으로 기존에 중복 표시되던 프로젝트가 사라질 수 있습니다. 프론트엔드 동작 확인 부탁드립니다.
- `convertToResponseDto`에서 링크 중복 제거와 프로젝트 중복 제거를 함께 처리합니다. 기존 동작과 일치하는지 확인 부탁드립니다.

## ⚠️ 주의사항

- [x] Breaking Change 없음 (API 스펙 변경 없음)
- [x] DB 마이그레이션 필요 없음
- [x] 환경 변수 추가/변경 없음
- [x] 의존성 추가/변경 없음

## 📝 추가 메모

`PlaygroundService` 인터페이스는 유지합니다 (외부 API 경계). 내부 구현 상세인 `getProjectsWithPagination`과 Playground와 무관한 `scrapLink`만 인터페이스에서 제거했습니다.

---

## ✅ PR 체크리스트

- [x] 코드 스타일 가이드 준수
- [x] Self Review 완료
- [ ] 테스트 코드 작성 및 통과
- [x] 문서 업데이트 (필요 시)
- [x] 커밋 메시지 컨벤션 준수
- [ ] 충돌(Conflict) 해결 완료