### PR TITLE
[TEST] ProjectServiceTest

### DIFF
--- a/src/test/java/sopt/org/homepage/global/common/util/ArrayUtilTest.java
+++ b/src/test/java/sopt/org/homepage/global/common/util/ArrayUtilTest.java
@@ -1,0 +1,162 @@
+package sopt.org.homepage.global.common.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ArrayUtil 단위 테스트")
+class ArrayUtilTest {
+
+    private final ArrayUtil arrayUtil = new ArrayUtil();
+
+    // ===== paginateArray =====
+
+    @Nested
+    @DisplayName("paginateArray - 페이지네이션")
+    class PaginateArray {
+
+        private final List<String> items = List.of("A", "B", "C", "D", "E", "F", "G");
+
+        @Test
+        @DisplayName("✅ 1페이지 조회 (limit=3)")
+        void firstPage() {
+            // when
+            List<String> result = arrayUtil.paginateArray(items, 1, 3);
+
+            // then
+            assertThat(result).containsExactly("A", "B", "C");
+        }
+
+        @Test
+        @DisplayName("✅ 2페이지 조회 (limit=3)")
+        void secondPage() {
+            // when
+            List<String> result = arrayUtil.paginateArray(items, 2, 3);
+
+            // then
+            assertThat(result).containsExactly("D", "E", "F");
+        }
+
+        @Test
+        @DisplayName("✅ 마지막 페이지 - limit보다 적은 데이터")
+        void lastPagePartial() {
+            // when - 7개 데이터, 3페이지, limit=3 → 1개만 남음
+            List<String> result = arrayUtil.paginateArray(items, 3, 3);
+
+            // then
+            assertThat(result).containsExactly("G");
+        }
+
+        @Test
+        @DisplayName("✅ 범위 초과 페이지 → 빈 목록")
+        void pageExceedsRange() {
+            // when - 7개 데이터인데 100페이지 요청
+            List<String> result = arrayUtil.paginateArray(items, 100, 3);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("✅ 빈 리스트 → 빈 목록")
+        void emptyList() {
+            // when
+            List<String> result = arrayUtil.paginateArray(Collections.emptyList(), 1, 10);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("✅ limit이 전체 크기보다 큰 경우 → 전체 반환")
+        void limitLargerThanSize() {
+            // when
+            List<String> result = arrayUtil.paginateArray(items, 1, 100);
+
+            // then
+            assertThat(result).containsExactly("A", "B", "C", "D", "E", "F", "G");
+        }
+    }
+
+    // ===== dropDuplication =====
+
+    @Nested
+    @DisplayName("dropDuplication - 중복 제거")
+    class DropDuplication {
+
+        @Test
+        @DisplayName("✅ 이름 기준 중복 제거")
+        void removeDuplicatesByName() {
+            // given
+            List<TestItem> items = List.of(
+                    new TestItem(1, "Alice"),
+                    new TestItem(2, "Bob"),
+                    new TestItem(3, "Alice"),
+                    new TestItem(4, "Charlie")
+            );
+
+            // when
+            List<TestItem> result = arrayUtil.dropDuplication(items, TestItem::name);
+
+            // then
+            assertThat(result).hasSize(3);
+            assertThat(result).extracting(TestItem::name)
+                    .containsExactly("Alice", "Bob", "Charlie");
+        }
+
+        @Test
+        @DisplayName("✅ 첫 번째 등장 항목 유지 (순서 보장)")
+        void keepsFirstOccurrence() {
+            // given
+            List<TestItem> items = List.of(
+                    new TestItem(1, "Alice"),
+                    new TestItem(2, "Alice"),
+                    new TestItem(3, "Alice")
+            );
+
+            // when
+            List<TestItem> result = arrayUtil.dropDuplication(items, TestItem::name);
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).id()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("✅ 중복 없는 경우 원본 그대로")
+        void noDuplicates() {
+            // given
+            List<TestItem> items = List.of(
+                    new TestItem(1, "Alice"),
+                    new TestItem(2, "Bob")
+            );
+
+            // when
+            List<TestItem> result = arrayUtil.dropDuplication(items, TestItem::name);
+
+            // then
+            assertThat(result).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("✅ 빈 리스트 → 빈 목록")
+        void emptyList() {
+            // when
+            List<TestItem> result = arrayUtil.dropDuplication(
+                    Collections.emptyList(), TestItem::name
+            );
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    // ===== Test Helper =====
+
+    private record TestItem(int id, String name) {
+    }
+}

--- a/src/test/java/sopt/org/homepage/project/ProjectServiceTest.java
+++ b/src/test/java/sopt/org/homepage/project/ProjectServiceTest.java
@@ -1,0 +1,155 @@
+package sopt.org.homepage.project;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sopt.org.homepage.global.common.dto.PaginateResponseDto;
+import sopt.org.homepage.global.common.util.ArrayUtil;
+import sopt.org.homepage.infrastructure.external.playground.PlaygroundService;
+import sopt.org.homepage.project.dto.request.GetProjectsRequestDto;
+import sopt.org.homepage.project.dto.response.ProjectDetailResponseDto;
+import sopt.org.homepage.project.dto.response.ProjectsResponseDto;
+
+@ExtendWith(MockitoExtension.class) // Mockito(Mock 라이브러리) 활성화
+@DisplayName("Project 서비스 테스트")
+class ProjectServiceTest {
+
+    @Mock
+    private PlaygroundService playgroundService; // 가짜 PlaygroundService
+
+    @Mock
+    private ArrayUtil arrayUtil; // 가짜 ArrayUtil
+
+    @InjectMocks
+    private ProjectService projectService; // 진짜 ProjectService 위의 Mock들을 자동으로 주입해줌
+
+    @Nested
+    @DisplayName("프로젝트 목록 조회")
+    class PaginateProjects {
+
+        @Test
+        @DisplayName("✅ 정상: generation 내림차순 정렬 후 페이지네이션")
+        void paginateProjects_SortedByGenerationDesc() {
+            // given     정렬 안 된 프로젝트 3개를 만듦
+            List<ProjectsResponseDto> unsorted = List.of(
+                    createProject(1L, "프로젝트A", 33),
+                    createProject(2L, "프로젝트B", 35),
+                    createProject(3L, "프로젝트C", 34)
+            );
+            // "playgroundService.getAllProjects()가 호출되면 unsorted를 반환해라"
+            //  new ArrayList로 감싸는 이유:List.of()는 불변이라 sort()가 안 됨
+            when(playgroundService.getAllProjects(any()))
+                    .thenReturn(new ArrayList<>(unsorted));
+
+            // "arrayUtil.paginateArray()가 호출되면 받은 리스트를 그대로 반환해라"
+            //  thenAnswer: 첫 번째 인자(정렬된 리스트)를 그대로 반환 → 페이지네이션 로직은 여기서 검증 대상이 아니니까 통과
+            when(arrayUtil.paginateArray(anyList(), eq(1), eq(10)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            GetProjectsRequestDto request = new GetProjectsRequestDto(1, 10, null, null);
+
+            // when     // 실제 테스트 대상 메서드 호출
+            PaginateResponseDto<ProjectsResponseDto> result =
+                    projectService.paginateProjects(request);
+
+            // then - 35기 → 34기 → 33기 순서
+            // 정렬 결과 확인: 35 → 34 → 33 순서여야 함
+            assertThat(result.getData())
+                    .extracting(ProjectsResponseDto::getGeneration)
+                    .containsExactly(35, 34, 33);
+            // extracting: 각 객체에서 generation 값만 추출 , containsExactly: 정확히 이 순서로 있어야 함
+            assertThat(result.getTotalCount()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("✅ 정상: generation이 null인 프로젝트는 맨 뒤로")
+        void paginateProjects_NullGenerationLast() {
+            // given
+            List<ProjectsResponseDto> projects = new ArrayList<>(List.of(
+                    createProject(1L, "프로젝트A", null),
+                    createProject(2L, "프로젝트B", 35),
+                    createProject(3L, "프로젝트C", 33)
+            ));
+            when(playgroundService.getAllProjects(any())).thenReturn(projects);
+            when(arrayUtil.paginateArray(anyList(), eq(1), eq(10)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            GetProjectsRequestDto request = new GetProjectsRequestDto(1, 10, null, null);
+
+            // when
+            PaginateResponseDto<ProjectsResponseDto> result =
+                    projectService.paginateProjects(request);
+
+            // then
+            assertThat(result.getData())
+                    .extracting(ProjectsResponseDto::getGeneration)
+                    .containsExactly(35, 33, null);
+        }
+
+        @Test
+        @DisplayName("✅ 정상: Playground API 결과가 비어있으면 빈 목록")
+        void paginateProjects_EmptyResult() {
+            // given
+            when(playgroundService.getAllProjects(any()))
+                    .thenReturn(new ArrayList<>());
+            when(arrayUtil.paginateArray(anyList(), eq(1), eq(10)))
+                    .thenReturn(List.of());
+
+            GetProjectsRequestDto request = new GetProjectsRequestDto(1, 10, null, null);
+
+            // when
+            PaginateResponseDto<ProjectsResponseDto> result =
+                    projectService.paginateProjects(request);
+
+            // then
+            assertThat(result.getData()).isEmpty();
+            assertThat(result.getTotalCount()).isEqualTo(0);
+        }
+    }
+
+    @Nested
+    @DisplayName("프로젝트 상세 조회")
+    class FindOne {
+
+        @Test
+        @DisplayName("✅ 정상: 프로젝트 상세 조회")
+        void findOne_Success() {
+            // given
+            ProjectDetailResponseDto expected = ProjectDetailResponseDto.builder()
+                    .id(1L)
+                    .name("테스트 프로젝트")
+                    .generation(35)
+                    .build();
+            when(playgroundService.getProjectDetail(1L)).thenReturn(expected);
+
+            // when
+            ProjectDetailResponseDto result = projectService.findOne(1L);
+
+            // then
+            assertThat(result.getName()).isEqualTo("테스트 프로젝트");
+            assertThat(result.getGeneration()).isEqualTo(35);
+        }
+    }
+
+    // ===== Helper Methods =====
+
+    private ProjectsResponseDto createProject(Long id, String name, Integer generation) {
+        return ProjectsResponseDto.builder()
+                .id(id)
+                .name(name)
+                .generation(generation)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

Related to #146
Related to #202 

## 📋 작업 내용 요약

리팩토링된 Project 도메인과 공용 유틸리티 클래스에 대한 단위 테스트를 추가했습니다.

### 주요 변경사항
- `ProjectServiceTest` 추가: Mock 기반 단위 테스트 (정렬, null 처리, 빈 결과)
- `ArrayUtilTest` 추가: `paginateArray` 페이지네이션 + `dropDuplication` 중복 제거 테스트

## 💡 구현 방법

**ProjectServiceTest — Mock 기반 단위 테스트를 선택한 이유:**
- Project 도메인은 자체 DB 없이 Playground 외부 API를 래핑하는 구조
- TestContainers 통합 테스트는 불가 (외부 API 의존), `docs/testing-guide.md`의 "외부 API 연동은 Mock 사용 가능" 가이드를 따름
- `PlaygroundService`를 Mock하고, `ProjectService`가 직접 하는 일(정렬)만 검증

**ArrayUtilTest — 별도 단위 테스트를 추가한 이유:**
- `paginateArray`는 `ProjectService`, `PlaygroundServiceImpl` 등 여러 곳에서 사용하는 공용 유틸
- 경계값 처리 로직(마지막 페이지, 범위 초과, 빈 리스트)이 있어 테스트 가치 충분
- `dropDuplication`도 Playground 프로젝트 중복 제거에 사용되므로 함께 검증

## 🧪 테스트

### 테스트 케이스

- [x] 단위 테스트 추가

### 테스트 시나리오

**ProjectServiceTest (4개):**
1. generation 내림차순 정렬 확인 (35 → 34 → 33)
2. null generation이 맨 뒤로 밀리는지 확인
3. Playground API 빈 결과 시 빈 목록 반환 확인
4. 프로젝트 상세 조회 위임 확인

**ArrayUtilTest - paginateArray (6개):**
1. 1페이지 정상 조회
2. 2페이지 정상 조회
3. 마지막 페이지 (limit보다 적은 데이터)
4. 범위 초과 페이지 → 빈 목록
5. 빈 리스트 입력 → 빈 목록
6. limit이 전체 크기보다 큰 경우 → 전체 반환

**ArrayUtilTest - dropDuplication (4개):**
1. 이름 기준 중복 제거
2. 첫 번째 등장 항목 유지 (순서 보장)
3. 중복 없는 경우 원본 그대로
4. 빈 리스트 → 빈 목록

## 🔍 리뷰 포인트

- `ProjectServiceTest`에서 `findOne()`은 단순 위임 메서드라 최소 검증만 했습니다. 불필요하다고 판단되면 제거 가능합니다.
- `ArrayUtilTest`에서 `paginateArray`의 page=0이나 음수 입력에 대한 테스트는 생략했습니다. `PaginateRequest`에서 `@Min(1)` 검증을 하고 있어 유효하지 않은 값이 도달하지 않는다고 판단했습니다.

## ⚠️ 주의사항

- [x] Breaking Change 없음
- [x] DB 마이그레이션 필요 없음
- [x] 환경 변수 추가/변경 없음
- [x] 의존성 추가/변경 없음

## 📝 추가 메모

프로젝트 테스트 전략 정리:

| 도메인 유형 | 테스트 방식 | 이유 |
|---|---|---|
| Light (Notification 등) | TestContainers 통합 | 자체 DB 있음 |
| Full DDD (Review 등) | 단위 + 통합 | 복잡한 비즈니스 규칙 |
| Project | **Mock 단위** | 자체 DB 없음, 외부 API 래핑 |
| ArrayUtil | **순수 단위** | 의존성 없는 유틸리티 |

---

## ✅ PR 체크리스트

- [x] 코드 스타일 가이드 준수
- [x] Self Review 완료
- [x] 테스트 코드 작성 및 통과
- [x] 문서 업데이트 (필요 시)
- [x] 커밋 메시지 컨벤션 준수
- [ ] 충돌(Conflict) 해결 완료