### PR TITLE
[FEAT] Micrometer 캐시 메트릭 계측 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,7 @@ bin/
 .vscode/
 
 ### config yml ###
-.env
+*.env
 
 ### Some additional ignores
 *.DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,9 @@ dependencies {
     implementation 'com.amazonaws:aws-lambda-java-core:1.4.0'
     implementation 'com.amazonaws:aws-lambda-java-events:3.16.1'
 
+    // Actuator + Micrometer (캐시 메트릭 계측용)
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
 
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/java/sopt/org/homepage/global/config/SecurityConfig.java
+++ b/src/main/java/sopt/org/homepage/global/config/SecurityConfig.java
@@ -55,6 +55,7 @@ public class SecurityConfig {
                                         .of(SWAGGER_URL)
                                         .map(AntPathRequestMatcher::antMatcher)
                                         .toArray(AntPathRequestMatcher[]::new)).permitAll()
+                                .requestMatchers("/actuator/**").permitAll()
                                 .requestMatchers(Stream
                                         .of(WHITELIST_URL)
                                         .map(AntPathRequestMatcher::antMatcher)

--- a/src/main/java/sopt/org/homepage/infrastructure/external/playground/PlaygroundMetrics.java
+++ b/src/main/java/sopt/org/homepage/infrastructure/external/playground/PlaygroundMetrics.java
@@ -1,0 +1,38 @@
+package sopt.org.homepage.infrastructure.external.playground;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * Playground 외부 API 관련 Micrometer 메트릭 이름 상수
+ * <p>
+ * 사용 가능한 메트릭: {@code playground.cache.hit} — 캐시 히트 횟수 {@code playground.cache.miss} — 캐시 미스 횟수 (= 외부 API 호출 트리거)
+ * {@code playground.api.call.count} — Playground API 실제 호출 횟수 (페이지네이션 단위) {@code playground.api.call.duration} —
+ * Playground API 전체 호출 소요 시간< Actuator 조회 예시: curl http://localhost:8080/actuator/metrics/playground.cache.hit curl
+ * http://localhost:8080/actuator/metrics/playground.api.call.duration
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class PlaygroundMetrics {
+
+    private static final String PREFIX = "playground";
+
+    /**
+     * 프로젝트 목록 캐시 히트 카운터
+     */
+    public static final String CACHE_HIT = PREFIX + ".cache.hit";
+
+    /**
+     * 프로젝트 목록 캐시 미스 카운터
+     */
+    public static final String CACHE_MISS = PREFIX + ".cache.miss";
+
+    /**
+     * Playground API 호출 카운터 (커서 기반 페이지네이션 1회 = 1 카운트)
+     */
+    public static final String API_CALL_COUNT = PREFIX + ".api.call.count";
+
+    /**
+     * Playground API 전체 호출 소요 시간 타이머 (fetchAllFromApi 전체)
+     */
+    public static final String API_CALL_DURATION = PREFIX + ".api.call.duration";
+}

--- a/src/main/java/sopt/org/homepage/infrastructure/external/playground/PlaygroundServiceImpl.java
+++ b/src/main/java/sopt/org/homepage/infrastructure/external/playground/PlaygroundServiceImpl.java
@@ -1,6 +1,8 @@
 package sopt.org.homepage.infrastructure.external.playground;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -31,6 +33,8 @@ public class PlaygroundServiceImpl implements PlaygroundService {
     private final AuthConfig authConfig;
     private final ArrayUtil arrayUtil;
     private final CacheService cacheService;
+    private final MeterRegistry meterRegistry;                // 🆕
+
     private static final String PROJECT_CACHE_KEY = "all_projects";
 
 
@@ -56,6 +60,7 @@ public class PlaygroundServiceImpl implements PlaygroundService {
 
     /**
      * 캐시에서 프로젝트 목록 조회, 없으면 API 호출 후 캐시 저장
+     * <p>Micrometer 메트릭으로 캐시 히트/미스를 계측한다.</p>
      */
     private List<PlaygroundProjectResponseDto> fetchProjectsWithCache() {
         List<PlaygroundProjectResponseDto> cached = cacheService.get(
@@ -63,8 +68,11 @@ public class PlaygroundServiceImpl implements PlaygroundService {
                 }
         );
         if (cached != null) {
+            meterRegistry.counter(PlaygroundMetrics.CACHE_HIT).increment();     // 🆕
             return cached;
         }
+
+        meterRegistry.counter(PlaygroundMetrics.CACHE_MISS).increment();        // 🆕
 
         try {
             List<PlaygroundProjectResponseDto> fetched = fetchAllFromApi();
@@ -78,14 +86,20 @@ public class PlaygroundServiceImpl implements PlaygroundService {
 
     /**
      * Playground API에서 커서 기반 페이지네이션으로 전체 프로젝트 조회
+     * <p>Micrometer Timer로 전체 소요 시간을 측정하고,
+     * Counter로 페이지네이션 단위 API 호출 횟수를 기록한다.</p>
      */
     private List<PlaygroundProjectResponseDto> fetchAllFromApi() {
+        Timer.Sample sample = Timer.start(meterRegistry);                       // 🆕
+
         final int limit = 20;
         int cursor = 0;
         int totalCount = 10;
         List<PlaygroundProjectResponseDto> response = new ArrayList<>();
 
         for (int i = 0; i < totalCount + 1; i = i + limit) {
+            meterRegistry.counter(PlaygroundMetrics.API_CALL_COUNT).increment(); // 🆕
+
             PlaygroundProjectAxiosResponseDto projectData = playgroundClient.getAllProjects(
                     limit, cursor
             );
@@ -104,6 +118,8 @@ public class PlaygroundServiceImpl implements PlaygroundService {
                 break;
             }
         }
+
+        sample.stop(meterRegistry.timer(PlaygroundMetrics.API_CALL_DURATION)); // 🆕
 
         return response;
     }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -92,3 +92,17 @@ sentry:
     minimum-event-level: warn
     minimum-breadcrumb-level: info
 
+# ============================================
+# Actuator 설정 (메트릭 노출)
+# ============================================
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, metrics
+      base-path: /actuator
+  endpoint:
+    health:
+      show-details: when-authorized
+    metrics:
+      enabled: true

--- a/src/main/resources/application-lambda-dev.yml
+++ b/src/main/resources/application-lambda-dev.yml
@@ -146,6 +146,13 @@ sentry:
 # Actuator 설정 (Lambda 최적화)
 # ============================================
 management:
+  endpoints:
+    web:
+      exposure:
+        include: health, metrics
+  endpoint:
+    metrics:
+      enabled: true
   health:
     diskspace:
       enabled: false               # Lambda 읽기 전용 파일시스템
@@ -159,3 +166,6 @@ logging:
     sopt.org.homepage: INFO
     org.hibernate.SQL: WARN        # SQL 로깅 최소화
     com.zaxxer.hikari: WARN
+
+
+


### PR DESCRIPTION
# 🔗 관련 이슈

Related to #204 
Related to #205 


## 📋 작업 내용 요약

프로젝트 조회 API(`GET /projects`)의 캐시 성능을 정량적으로 측정하기 위한 Micrometer 기반 메트릭 계측 인프라를 구축합니다.
이후 시나리오별 성능 비교(Baseline → Caffeine → Lambda + Redis)의 공통 측정 기반이 됩니다.

### 주요 변경사항

- `spring-boot-starter-actuator` 의존성 추가
- `PlaygroundMetrics` 상수 클래스 신규 생성 — 메트릭 이름 중앙 관리
- `PlaygroundServiceImpl`에 Micrometer Counter/Timer 계측 추가
  - `playground.cache.hit` / `playground.cache.miss`: 캐시 히트/미스 카운터
  - `playground.api.call.count`: Playground API 페이지네이션 단위 호출 횟수
  - `playground.api.call.duration`: API 전체 호출 소요 시간 (Timer)
- dev / lambda-dev 프로파일에 Actuator metrics 엔드포인트 노출 설정
- `SecurityConfig`에서 `/actuator/**` 경로 permitAll 추가

## 💡 구현 방법

### 메트릭 계측 방식

`MeterRegistry`를 `@RequiredArgsConstructor`로 주입받아 기존 코드에 최소 침투로 계측합니다.

- **Counter**: `fetchProjectsWithCache()`에서 캐시 히트/미스 시 `meterRegistry.counter(...).increment()`
- **Timer**: `fetchAllFromApi()`에서 `Timer.Sample` 패턴으로 전체 소요 시간 측정
- **Counter (API 호출)**: 페이지네이션 루프 내부에서 1회 호출마다 카운터 증가

### 메트릭 이름 관리

`PlaygroundMetrics` 상수 클래스를 별도로 분리하여:
- 오타로 인한 메트릭 불일치 방지
- 메트릭 목록을 한 곳에서 파악 가능
- 이후 Redis 캐시 구현체에서도 동일 메트릭 이름 재사용

### 프로파일별 Actuator 설정

| 프로파일 | metrics 엔드포인트 | 비고 |
|---|---|---|
| dev | 노출 (`/actuator/metrics`) | EC2 환경에서 직접 조회 |
| lambda-dev | 노출 | CloudWatch Logs와 병행 |
| test | 비활성화 (기존 유지) | 테스트 속도 영향 최소화 |

## 📸 스크린샷 / 실행 결과

### 1회 호출 후 (캐시 미스 발생)
$ curl -s http://localhost:8080/v2/actuator/metrics/playground.cache.miss | jq '.measurements[0].value'
1.0

- 애플리케이션 기동 후 첫 요청에서는 캐시에 데이터가 없어 cache miss가 1회 발생
- 이후 Playground API 호출 로직이 실행됨

### 동일 API 재호출 (캐시 히트)
$ curl -s http://localhost:8080/v2/actuator/metrics/playground.cache.hit | jq '.measurements[0].value'
1.0

- 동일 요청 재호출 시 캐시된 데이터를 사용하여 cache hit 1회 증가
- 캐시가 정상적으로 동작하며, 이후 외부 API 호출이 발생하지 않음을 확인

### 외부 Playground API 호출 횟수
$ curl -s http://localhost:8080/v2/actuator/metrics/playground.api.call.count | jq '.measurements[0].value'
5.0

- 캐시 miss 1회 시, 커서 기반 페이지네이션으로 인해 외부 API가 총 5회 호출
- “요청 수”가 아닌 실제 외부 API 호출 횟수를 계측함으로써, 캐시 적용 전 외부 의존 비용을 정량적으로 파악 가능

### 외부 API 전체 호출 소요 시간
$ curl -s http://localhost:8080/v2/actuator/metrics/playground.api.call.duration | jq '.measurements'
[
  { "statistic": "COUNT", "value": 1.0 },
  { "statistic": "TOTAL_TIME", "value": 8.843287083 },
  { "statistic": "MAX", "value": 0.0 }
]
- COUNT = 1 → 외부 API 호출 “묶음(fetchAllFromApi 전체)” 기준으로 1회 측정됨
- TOTAL_TIME ≈ 8.84s → 캐시 miss 시, 외부 API 전체 호출에 약 8.8초가 소요됨
- 캐시 hit 시 해당 Timer는 실행되지 않으므로,캐시 적용 전/후의 성능 차이를 명확히 비교 가능

## 정리
- 캐시 miss 1회 → 외부 API 5회 호출, 총 약 8.8초 소요
- 캐시 hit 시 → 외부 API 호출 0회
- 이를 통해 캐시 전략 변경(Caffeine → Lambda → Redis)에 따른 외부 API 호출 감소율, 응답 시간 개선 효과를 동일한 지표로 비교 가능



## 🧪 테스트

### 테스트 케이스

- [x] 수동 테스트 완료

### 테스트 시나리오

1. 앱 기동 후 `GET /v2/projects` 첫 호출 → `playground.cache.miss` = 1, `playground.api.call.count` ≥ 1 확인
2. 동일 API 재호출 → `playground.cache.hit` = 1, `playground.api.call.count` 값 변화 없음 확인
3. `/actuator/metrics` 에서 `playground.*` 메트릭 4종 모두 노출 확인
4. `/actuator/metrics/playground.api.call.duration`에서 TOTAL_TIME > 0 확인

## 🔍 리뷰 포인트

- `PlaygroundServiceImpl`의 메트릭 계측 위치가 적절한지 (특히 `fetchAllFromApi()` 루프 내부의 카운터)
- `Timer.Sample` 패턴 사용이 적절한지 (`Timer.record(Supplier)` 대비 선택 이유: fetchAllFromApi가 checked exception 가능성)
- `PlaygroundMetrics` 상수 클래스의 네이밍 컨벤션 (`playground.cache.hit` vs `cache.project.hit`)

## ⚠️ 주의사항

- [x] Breaking Change 없음
- [x] DB 마이그레이션 필요 없음
- [ ] 환경 변수 추가/변경 없음
- [ ] 의존성 추가: `spring-boot-starter-actuator`

> `/actuator/metrics` 엔드포인트가 외부에 노출되므로, 운영 환경에서는 IP 제한 또는 인증 추가를 검토해야 합니다.
> 현재는 dev/성능 측정 목적이므로 permitAll로 설정했습니다.

## 📝 추가 메모

- 이 PR은 [EPIC] 프로젝트 조회 API 캐시 전략 최적화의 첫 번째 작업입니다
- 이후 이슈 #2 (k6 부하 테스트)에서 이 메트릭을 활용하여 시나리오별 성능을 측정합니다
- Lambda 환경에서는 Actuator 접근이 제한적이므로, 기존 `CacheServiceImpl`의 `log.info("Cache HIT/MISS")` 로그도 유지하여 CloudWatch Logs Insights로 병행 추적 가능합니다

---

## ✅ PR 체크리스트

- [ ] 코드 스타일 가이드 준수
- [ ] Self Review 완료
- [ ] 테스트 코드 작성 및 통과
- [ ] 문서 업데이트 (필요 시)
- [ ] 커밋 메시지 컨벤션 준수
- [ ] 충돌(Conflict) 해결 완료