### PR TITLE
[FEAT] k6 부하 테스트 스크립트 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,9 @@ bin/
 src/main/resources/application.yml
 
 lambda/.env
+
+# k6 결과 파일 (용량이 클 수 있음)
+
+results/*.json
+results/*.csv
+!results/.gitkeep

--- a/k6/README.md  
+++ b/k6/README.md  
@@ -1,0 +1,83 @@
+# 🚀 k6 부하 테스트
+
+프로젝트 조회 API(`GET /projects`) 캐시 전략별 성능 비교를 위한 k6 부하 테스트 스크립트입니다.
+
+## 사전 준비
+```bash
+# k6 설치 (macOS)
+brew install k6
+
+# 버전 확인
+k6 version
+```
+
+## 스크립트 목록
+
+| 스크립트 | 목적 | 시나리오 |
+|---|---|---|
+| `load-test-projects.js` | 메인 부하 테스트 | 초당 30 요청, 2분간 (약 3,600 요청) |
+| `load-test-cold-warm.js` | Cold/Warm 분리 측정 | VU 10개 × 20회 (200 요청) |
+| `collect-metrics.sh` | Actuator 메트릭 수집 | 캐시 히트율, API 호출 횟수 |
+
+## 실행 방법
+
+### EC2 환경 (context-path: `/v2`)
+```bash
+# 메인 부하 테스트
+k6 run --env BASE_URL=http://localhost:8080 --env CTX_PATH=/v2 k6/load-test-projects.js
+
+# Cold/Warm 분리 측정
+k6 run --env BASE_URL=http://localhost:8080 --env CTX_PATH=/v2 k6/load-test-cold-warm.js
+
+# 메트릭 수집
+chmod +x k6/collect-metrics.sh
+./k6/collect-metrics.sh http://localhost:8080 /v2
+```
+
+### Lambda 환경 (context-path 없음)
+```bash
+# 메인 부하 테스트
+k6 run --env BASE_URL=https://<API-GATEWAY-URL> --env CTX_PATH= k6/load-test-projects.js
+
+# Cold/Warm 분리 측정
+k6 run --env BASE_URL=https://<API-GATEWAY-URL> --env CTX_PATH= k6/load-test-cold-warm.js
+```
+
+## 결과 확인
+
+### k6 출력 주요 지표
+
+http_req_duration .......: avg=XXms  min=XXms  med=XXms  max=XXms  p(90)=XXms  p(95)=XXms
+
+- **avg**: 평균 응답시간
+- **med (P50)**: 중앙값
+- **p(95)**: 95번째 백분위
+- **http_reqs**: 총 요청 수 / 초당 처리량(RPS)
+
+### Actuator 메트릭
+```bash
+# 부하 테스트 후 수집
+./k6/collect-metrics.sh http://localhost:8080 /v2
+```
+
+## 시나리오별 측정 워크플로우
+
+1. 애플리케이션 재시작 (Micrometer 메트릭 초기화)
+2. 사전 메트릭 수집 -   ./k6/collect-metrics.sh ...   # 값이 0인지 확인
+3. k6 부하 테스트 실행 -    k6 run ...
+4. 사후 메트릭 수집-    ./k6/collect-metrics.sh ...   # 히트율, 외부 API 호출 횟수 확인
+5. 결과를 이슈 코멘트에 기록
+
+
+## 테스트 조건 조정
+
+`load-test-projects.js`의 `options.scenarios.constant_load`에서:
+```javascript
+rate: 30,          // 초당 요청 수 (트래픽에 따라 조정)
+duration: '2m',    // 테스트 지속 시간
+```
+
+> ⚠️ Playground 외부 API에 과도한 부하를 주지 않도록,
+> 캐시 미적용 시나리오에서는 rate를 낮추는 것을 권장합니다.
+
+

--- a/k6/collect-metrics.sh
+++ b/k6/collect-metrics.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+# ============================================
+# Actuator 메트릭 수집 스크립트
+# ============================================
+#
+# 사용법:
+#   ./collect-metrics.sh [BASE_URL] [CTX_PATH]
+#
+# 예시:
+#   ./collect-metrics.sh http://localhost:8080 /v2
+#   ./collect-metrics.sh http://13.125.203.123:8080 /v2
+#
+# 수집 메트릭:
+#   - playground.cache.hit (캐시 히트 수)
+#   - playground.cache.miss (캐시 미스 수 = 외부 API 호출 트리거)
+#   - playground.api.call.count (Playground API 호출 횟수)
+#   - playground.api.call.duration (API 호출 소요 시간)
+#
+# ============================================
+
+set -euo pipefail
+
+# 색상 정의
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+# 인자 파싱
+BASE_URL="${1:-http://localhost:8080}"
+CTX_PATH="${2:-/v2}"
+ACTUATOR_URL="${BASE_URL}${CTX_PATH}/actuator/metrics"
+
+echo -e "${CYAN}============================================${NC}"
+echo -e "${CYAN}📊 Actuator 메트릭 수집${NC}"
+echo -e "${CYAN}============================================${NC}"
+echo -e "대상: ${ACTUATOR_URL}"
+echo ""
+
+# 메트릭 조회 함수
+get_metric_value() {
+  local metric_name=$1
+  local url="${ACTUATOR_URL}/${metric_name}"
+  local response
+
+  response=$(curl -s --max-time 5 "$url" 2>/dev/null)
+
+  if [ -z "$response" ] || echo "$response" | grep -q "404\|error\|Not Found"; then
+    echo "N/A"
+    return
+  fi
+
+  # COUNT 값 추출
+  echo "$response" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    measurements = data.get('measurements', [])
+    for m in measurements:
+        if m['statistic'] == 'COUNT':
+            print(m['value'])
+            break
+    else:
+        print('N/A')
+except:
+    print('N/A')
+" 2>/dev/null
+}
+
+# Timer의 TOTAL_TIME 조회 함수
+get_timer_total() {
+  local metric_name=$1
+  local url="${ACTUATOR_URL}/${metric_name}"
+  local response
+
+  response=$(curl -s --max-time 5 "$url" 2>/dev/null)
+
+  if [ -z "$response" ]; then
+    echo "N/A"
+    return
+  fi
+
+  echo "$response" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    measurements = data.get('measurements', [])
+    result = {}
+    for m in measurements:
+        result[m['statistic']] = m['value']
+    count = result.get('COUNT', 0)
+    total = result.get('TOTAL_TIME', 0)
+    avg = total / count if count > 0 else 0
+    print(f'{total:.3f}s total, {avg:.3f}s avg ({int(count)} calls)')
+except:
+    print('N/A')
+" 2>/dev/null
+}
+
+# 메트릭 수집
+echo -e "${GREEN}▶ 캐시 메트릭${NC}"
+HIT=$(get_metric_value "playground.cache.hit")
+MISS=$(get_metric_value "playground.cache.miss")
+echo "  캐시 히트:    ${HIT}"
+echo "  캐시 미스:    ${MISS}"
+
+# 히트율 계산
+if [ "$HIT" != "N/A" ] && [ "$MISS" != "N/A" ]; then
+  HIT_RATE=$(python3 -c "
+h = float($HIT)
+m = float($MISS)
+total = h + m
+rate = (h / total * 100) if total > 0 else 0
+print(f'{rate:.1f}%')
+" 2>/dev/null)
+  echo -e "  ${YELLOW}캐시 히트율:  ${HIT_RATE}${NC}"
+fi
+
+echo ""
+echo -e "${GREEN}▶ API 호출 메트릭${NC}"
+API_COUNT=$(get_metric_value "playground.api.call.count")
+API_DURATION=$(get_timer_total "playground.api.call.duration")
+echo "  API 호출 수:  ${API_COUNT}"
+echo "  API 소요 시간: ${API_DURATION}"
+
+echo ""
+echo -e "${CYAN}============================================${NC}"
+echo -e "${CYAN}수집 완료: $(date '+%Y-%m-%d %H:%M:%S')${NC}"
+echo -e "${CYAN}============================================${NC}"

--- a/k6/load-test-cold-warm.js
+++ b/k6/load-test-cold-warm.js
@@ -1,0 +1,119 @@
+import http from 'k6/http';
+import {check, group, sleep} from 'k6';
+import {Counter, Trend} from 'k6/metrics';
+
+// ============================================
+// 커스텀 메트릭
+// ============================================
+const coldLatency = new Trend('cold_start_latency', true);
+const warmLatency = new Trend('warm_request_latency', true);
+const coldCount = new Counter('cold_request_count');
+const warmCount = new Counter('warm_request_count');
+
+// ============================================
+// 테스트 설정
+// ============================================
+//
+// 이 스크립트는 Cold Start(캐시 미스)와 Warm(캐시 히트)를 분리 측정합니다.
+//
+// Lambda 환경에서 의미 있는 측정을 위해:
+// - 각 VU의 첫 요청 = Cold (새 Lambda 인스턴스 or 캐시 비어있음)
+// - 이후 요청 = Warm (동일 인스턴스에서 캐시 히트 기대)
+//
+// VU를 높이면 여러 Lambda 인스턴스가 생성되어
+// Cold Start 비율이 증가하는 것을 관측할 수 있음
+//
+export const options = {
+    scenarios: {
+        cold_warm_test: {
+            executor: 'per-vu-iterations',
+            vus: 10,                 // 10개 VU (Lambda에서는 각각 별도 인스턴스 가능)
+            iterations: 20,          // VU당 20회 반복 (총 200 요청)
+        },
+    },
+    thresholds: {
+        warm_request_latency: ['p(95)<1000'],   // Warm P95 < 1초
+    },
+};
+
+// ============================================
+// 환경변수 기반 URL 구성
+// ============================================
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+const CTX_PATH = __ENV.CTX_PATH !== undefined ? __ENV.CTX_PATH : '/v2';
+const PROJECTS_URL = `${BASE_URL}${CTX_PATH}/projects`;
+
+// ============================================
+// 테스트 시작 시 설정 출력
+// ============================================
+export function setup() {
+    console.log('========================================');
+    console.log('Cold/Warm Split Measurement');
+    console.log(`Target URL: ${PROJECTS_URL}`);
+    console.log(`VUs: ${options.scenarios.cold_warm_test.vus}`);
+    console.log(`Iterations per VU: ${options.scenarios.cold_warm_test.iterations}`);
+    console.log('========================================');
+
+    return {projectsUrl: PROJECTS_URL};
+}
+
+// ============================================
+// 메인 테스트 로직
+// ============================================
+export default function (data) {
+    const iteration = __ITER;   // 현재 VU 내 반복 횟수 (0부터 시작)
+    const vuId = __VU;          // 현재 VU ID
+
+    if (iteration === 0) {
+        // ─── Cold Start: 각 VU의 첫 번째 요청 ───
+        // Lambda에서는 새 인스턴스 할당 가능 → 캐시 비어있음
+        group('Cold Start', function () {
+            const res = http.get(data.projectsUrl, {
+                tags: {name: 'GET /projects [cold]', type: 'cold'},
+                timeout: '30s',        // Cold Start는 시간이 더 걸릴 수 있음
+            });
+
+            check(res, {
+                'cold: status 200': (r) => r.status === 200,
+            });
+
+            coldLatency.add(res.timings.duration);
+            coldCount.add(1);
+
+            console.log(`[VU ${vuId}] Cold: ${res.timings.duration.toFixed(0)}ms (status: ${res.status})`);
+        });
+
+        // Cold → Warm 전환 대기 (캐시 저장 완료 보장)
+        sleep(1);
+
+    } else {
+        // ─── Warm Request: 이후 요청 ───
+        // 동일 인스턴스라면 캐시 히트 기대
+        group('Warm Request', function () {
+            const res = http.get(data.projectsUrl, {
+                tags: {name: 'GET /projects [warm]', type: 'warm'},
+                timeout: '10s',
+            });
+
+            check(res, {
+                'warm: status 200': (r) => r.status === 200,
+                'warm: response time < 500ms': (r) => r.timings.duration < 500,
+            });
+
+            warmLatency.add(res.timings.duration);
+            warmCount.add(1);
+        });
+
+        sleep(0.3);
+    }
+}
+
+// ============================================
+// 테스트 종료 후 요약
+// ============================================
+export function teardown(data) {
+    console.log('========================================');
+    console.log('Cold/Warm test completed.');
+    console.log(`Target: ${data.projectsUrl}`);
+    console.log('========================================');
+}

--- a/k6/load-test-projects.js
+++ b/k6/load-test-projects.js
@@ -1,0 +1,112 @@
+import http from 'k6/http';
+import {check} from 'k6';
+import {Counter, Rate, Trend} from 'k6/metrics';
+
+// ============================================
+// 커스텀 메트릭
+// ============================================
+const errorRate = new Rate('error_rate');
+const projectsLatency = new Trend('projects_latency', true); // true = 시간 단위 사용
+const successCount = new Counter('success_count');
+const failCount = new Counter('fail_count');
+
+// ============================================
+// 테스트 설정
+// ============================================
+//
+// 환경변수:
+//   BASE_URL  - 대상 서버 URL (기본: http://localhost:8080)
+//   CTX_PATH  - context-path (기본: /v2, Lambda는 빈 문자열)
+//
+// 사용 예시:
+//   [EC2]    k6 run --env BASE_URL=http://localhost:8080 --env CTX_PATH=/v2 load-test-projects.js
+//   [Lambda] k6 run --env BASE_URL=https://<api-gw-url> --env CTX_PATH= load-test-projects.js
+//
+export const options = {
+    scenarios: {
+        // ─── 시나리오: Constant Arrival Rate ───
+        // 초당 고정 요청률로 부하를 가함
+        // 서버 응답과 무관하게 일정한 부하를 유지하므로
+        // 캐시 유무에 따른 처리 능력 차이를 명확히 비교 가능
+        constant_load: {
+            executor: 'constant-arrival-rate',
+            rate: 30,                // 초당 30 요청
+            timeUnit: '1s',
+            duration: '2m',          // 2분간 유지 (총 약 3,600 요청)
+            preAllocatedVUs: 50,     // 초기 VU 수
+            maxVUs: 100,             // 최대 VU 수
+        },
+    },
+    thresholds: {
+        http_req_duration: ['p(95)<3000'],   // P95 < 3초
+        error_rate: ['rate<0.05'],           // 에러율 < 5%
+    },
+};
+
+// ============================================
+// 환경변수 기반 URL 구성
+// ============================================
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+const CTX_PATH = __ENV.CTX_PATH !== undefined ? __ENV.CTX_PATH : '/v2';
+const PROJECTS_URL = `${BASE_URL}${CTX_PATH}/projects`;
+
+// ============================================
+// 테스트 시작 시 설정 출력
+// ============================================
+export function setup() {
+    console.log('========================================');
+    console.log(`Target URL: ${PROJECTS_URL}`);
+    console.log(`Rate: ${options.scenarios.constant_load.rate} req/s`);
+    console.log(`Duration: ${options.scenarios.constant_load.duration}`);
+    console.log('========================================');
+
+    // 사전 확인: 서버 응답 가능 여부
+    const res = http.get(PROJECTS_URL);
+    if (res.status !== 200) {
+        console.error(`❌ Pre-check failed! Status: ${res.status}`);
+        console.error(`   URL: ${PROJECTS_URL}`);
+        console.error(`   Body: ${res.body ? res.body.substring(0, 200) : 'empty'}`);
+    } else {
+        console.log(`✅ Pre-check passed. Status: ${res.status}`);
+    }
+
+    return {projectsUrl: PROJECTS_URL};
+}
+
+// ============================================
+// 메인 테스트 로직
+// ============================================
+export default function (data) {
+    const res = http.get(data.projectsUrl, {
+        tags: {name: 'GET /projects'},
+        timeout: '10s',
+    });
+
+    // 응답 검증
+    const passed = check(res, {
+        'status is 200': (r) => r.status === 200,
+        'response time < 1000ms': (r) => r.timings.duration < 1000,
+        'response time < 3000ms': (r) => r.timings.duration < 3000,
+        'has response body': (r) => r.body && r.body.length > 0,
+    });
+
+    // 커스텀 메트릭 기록
+    projectsLatency.add(res.timings.duration);
+    errorRate.add(!passed);
+
+    if (passed) {
+        successCount.add(1);
+    } else {
+        failCount.add(1);
+    }
+}
+
+// ============================================
+// 테스트 종료 후 요약
+// ============================================
+export function teardown(data) {
+    console.log('========================================');
+    console.log('Load test completed.');
+    console.log(`Target: ${data.projectsUrl}`);
+    console.log('========================================');
+}


### PR DESCRIPTION
# 🔗 관련 이슈

Related to #이슈번호

## 📋 작업 내용 요약

프로젝트 조회 API(`GET /projects`) 캐시 전략별 성능 비교를 위한 k6 부하 테스트 스크립트를 작성합니다.
5가지 시나리오(①~⑤)에서 동일한 테스트 조건으로 실행하여 공정한 비교가 가능하도록 합니다.

### 주요 변경사항

- `k6/load-test-projects.js` — 메인 부하 테스트 스크립트 (초당 30 요청, 2분간)
- `k6/load-test-cold-warm.js` — Cold Start vs Warm 요청 분리 측정 (Lambda 시나리오용)
- `k6/collect-metrics.sh` — 부하 테스트 전후 Actuator 메트릭 수집 헬퍼 스크립트
- `k6/README.md` — 설치, 실행, 결과 확인 가이드

## 💡 구현 방법

### 환경 전환 전략

EC2(context-path: `/v2`)와 Lambda(context-path 없음)를 동일 스크립트로 테스트하기 위해,
`BASE_URL`과 `CTX_PATH` 환경변수를 사용합니다:

```bash
# EC2
k6 run --env BASE_URL=http://localhost:8080 --env CTX_PATH=/v2 k6/load-test-projects.js

# Lambda
k6 run --env BASE_URL=https:// --env CTX_PATH= k6/load-test-projects.js
```

### 부하 테스트 시나리오 선택 이유

`constant-arrival-rate` executor를 사용한 이유:
- 서버 응답 속도와 무관하게 초당 고정 요청률을 유지
- 캐시 히트(빠른 응답) vs 캐시 미스(느린 응답) 상황에서 동일한 부하 조건 보장
- 서버가 느려지면 VU가 자동 증가하여 실제 부하 패턴을 반영

### Cold/Warm 분리 측정 방식

`per-vu-iterations` executor로 각 VU의 첫 요청(`__ITER === 0`)을 Cold Start로 분류:
- Lambda에서 VU 수를 높이면 여러 인스턴스 생성 → Cold 비율 증가 관측 가능
- 커스텀 메트릭(`cold_start_latency`, `warm_request_latency`)으로 분리 집계

### 메트릭 수집 워크플로우

k6 자체로는 서버 내부의 캐시 히트율/API 호출 횟수를 측정할 수 없으므로,
`collect-metrics.sh`로 Actuator 엔드포인트에서 보완 데이터를 수집합니다:

```
1. 앱 재시작 (메트릭 0 초기화)
2. collect-metrics.sh 실행 (사전 — 0 확인)
3. k6 run 실행 (부하 테스트)
4. collect-metrics.sh 실행 (사후 — 히트율, API 호출 횟수)
5. 결과를 이슈 코멘트에 기록
```

## 📸 스크린샷 / 실행 결과

### 로컬 테스트 실행 예시

```bash
$ k6 run --env BASE_URL=http://localhost:8080 --env CTX_PATH=/v2 k6/load-test-projects.js

          /\      |‾‾| /‾‾/   /‾‾/
     /\  /  \     |  |/  /   /  /
    /  \/    \    |     (   /   ‾‾\
   /          \   |  |\  \ |  (‾)  |
  / __________ \  |__| \__\ \_____/ .io

  execution: local
     script: k6/load-test-projects.js
     output: -

  scenarios: (100.00%) 1 scenario, 100 max VUs, 2m30s max duration
           * constant_load: 30.00 iterations/s for 2m0s

  ========================================
  Target URL: http://localhost:8080/v2/projects
  Rate: 30 req/s
  Duration: 2m
  ========================================
```

### 메트릭 수집 예시

```bash
$ ./k6/collect-metrics.sh http://localhost:8080 /v2

============================================
📊 Actuator 메트릭 수집
============================================
▶ 캐시 메트릭
  캐시 히트:    3599.0
  캐시 미스:    1.0
  캐시 히트율:  99.97%

▶ API 호출 메트릭
  API 호출 수:  5.0
  API 소요 시간: 8.843s total, 8.843s avg (1 calls)
```

> ⚠️ 위 수치는 예시이며, 실제 측정값으로 교체 필요

## 🧪 테스트

### 테스트 케이스

- [ ] 수동 테스트 완료

### 테스트 시나리오

1. `k6 run --env BASE_URL=http://localhost:8080 --env CTX_PATH=/v2 k6/load-test-projects.js` — 정상 실행 및 결과 출력 확인
2. `k6 run --env BASE_URL=http://localhost:8080 --env CTX_PATH=/v2 k6/load-test-cold-warm.js` — Cold/Warm 분리 메트릭 확인
3. `./k6/collect-metrics.sh http://localhost:8080 /v2` — 캐시 히트율 및 API 호출 횟수 정상 출력 확인
4. 잘못된 BASE_URL 입력 시 setup()에서 Pre-check 실패 메시지 출력 확인

## 🔍 리뷰 포인트

- `constant-arrival-rate`의 rate(30 req/s)와 duration(2분)이 SOPT 홈페이지 트래픽 대비 적절한지
- `load-test-cold-warm.js`에서 `__ITER === 0`으로 Cold를 판별하는 것이 Lambda 환경에서 유의미한지 (VU가 동일 인스턴스에 매핑되는 것은 아님)
- `collect-metrics.sh`의 python3 의존성이 팀원 환경에서 문제 없을지

## ⚠️ 주의사항

- [x] Breaking Change 없음
- [x] DB 마이그레이션 필요 없음
- [x] 환경 변수 추가/변경 없음
- [x] 의존성 추가/변경 없음 (k6는 로컬 도구, 프로젝트 의존성 아님)

> ⚠️ 캐시 미적용(Baseline) 시나리오에서는 매 요청마다 Playground API를 호출하므로,
> rate를 낮추거나(10 req/s) duration을 줄여서(30초) Playground 서버에 과부하를 주지 않도록 주의

## 📝 추가 메모

- k6 스크립트는 프로젝트 코드와 독립적이므로, 이후 시나리오별 측정 시 스크립트 변경 없이 환경변수만 바꿔서 실행합니다
- Lambda 환경에서는 `collect-metrics.sh` 대신 CloudWatch Logs Insights로 캐시 메트릭을 집계합니다 (이슈 #1의 기존 로그 활용)
- 결과 JSON 파일은 `k6/results/`에 저장되며 `.gitignore`로 git 추적에서 제외됩니다

---

## ✅ PR 체크리스트

- [ ] 코드 스타일 가이드 준수
- [ ] Self Review 완료
- [ ] 테스트 코드 작성 및 통과
- [ ] 문서 업데이트 (k6/README.md 작성 완료)
- [ ] 커밋 메시지 컨벤션 준수
- [ ] 충돌(Conflict) 해결 완료