### PR TITLE
[FEAT] 파트 소개, 핵심 가치, FAQ 조회 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ lambda/.env
 results/*.json
 results/*.csv
 !results/.gitkeep
+
+# CLAUDE
+CLAUDE.md

--- a/src/main/java/sopt/org/homepage/application/recruitpage/controller/RecruitPageController.java
+++ b/src/main/java/sopt/org/homepage/application/recruitpage/controller/RecruitPageController.java
@@ -1,0 +1,29 @@
+package sopt.org.homepage.application.recruitpage.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sopt.org.homepage.application.recruitpage.dto.RecruitMainPageResponse;
+import sopt.org.homepage.application.recruitpage.service.RecruitPageService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("recruit-page")
+@Tag(name = "Recruit Page", description = "지원서 API")
+public class RecruitPageController {
+
+    private final RecruitPageService recruitPageService;
+
+    @Operation(
+            summary = "지원서 메인 페이지 조회",
+            description = "지원서 메인 페이지 데이터를 조회합니다"
+    )
+    @GetMapping("")
+    ResponseEntity<RecruitMainPageResponse> getRecruitMainPage(){
+        return ResponseEntity.ok(recruitPageService.getRecruitMainPageData());
+    }
+}

--- a/src/main/java/sopt/org/homepage/application/recruitpage/dto/RecruitMainPageResponse.java
+++ b/src/main/java/sopt/org/homepage/application/recruitpage/dto/RecruitMainPageResponse.java
@@ -1,0 +1,96 @@
+package sopt.org.homepage.application.recruitpage.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import sopt.org.homepage.application.homepage.controller.dto.AboutPageResponse;
+import sopt.org.homepage.application.homepage.controller.dto.MainPageResponse;
+import sopt.org.homepage.application.homepage.controller.dto.RecruitPageResponse;
+import sopt.org.homepage.corevalue.dto.CoreValueView;
+import sopt.org.homepage.faq.dto.FAQView;
+import sopt.org.homepage.generation.dto.GenerationDetailView;
+import sopt.org.homepage.part.dto.PartIntroductionView;
+import sopt.org.homepage.recruitpartintroduction.dto.RecruitPartIntroductionView;
+
+import java.util.List;
+
+/*
+    공식홈페이지가 아닌 리크루팅 지원서 페이지의 메인 페이지 데이터 조회 응답 DTO입니다.
+    파트 소개, 핵심 가치, FAQ
+ */
+@Builder
+public record RecruitMainPageResponse(
+        @Schema(description = "모집 헤더 이미지 URL")
+        String recruitHeaderImage,
+
+        @Schema(description = "파트별 소개")
+        List<PartIntroduction> partIntroduction,
+
+        @Schema(description = "핵심 가치")
+        List<CoreValue> coreValue,
+
+        @Schema(description = "자주 묻는 질문(FAQ)")
+        List<RecruitQuestion> recruitQuestion
+
+) {
+
+    @Builder
+    public record PartIntroduction(
+            String part,
+            String description
+    ) {
+    }
+
+    @Builder
+    public record CoreValue(
+            String value,
+            String description,
+            String image
+    ) {
+    }
+
+    @Builder
+    public record RecruitQuestion(
+            String part,
+            List<Question> questions
+    ) {
+        @Builder
+        public record Question(
+                String question,
+                String answer
+        ) {
+        }
+    }
+
+    public static RecruitMainPageResponse from(GenerationDetailView generation, List<CoreValueView> coreValues,
+                                               List<PartIntroductionView> partIntroductions,
+                                               List<FAQView> faqs){
+
+        return RecruitMainPageResponse.builder()
+                .recruitHeaderImage(generation.headerImage())
+                .partIntroduction(partIntroductions.stream()
+                        .map(pi -> PartIntroduction.builder()
+                                .part(pi.part())
+                                .description(pi.description())
+                                .build())
+                        .toList())
+                .coreValue(coreValues.stream()
+                        .map(cv -> CoreValue.builder()
+                                .value(cv.value())
+                                .description(cv.description())
+                                .image(cv.imageUrl())
+                                .build())
+                        .toList())
+                .recruitQuestion(faqs.stream()
+                        .map(f -> RecruitQuestion.builder()
+                                .part(f.part().getValue())
+                                .questions(f.questions().stream()
+                                        .map(qav -> RecruitQuestion.Question.builder()
+                                                .question(qav.question())
+                                                .answer(qav.answer())
+                                                .build())
+                                        .toList())
+                                .build())
+                        .toList())
+                .build();
+    }
+}

--- a/src/main/java/sopt/org/homepage/application/recruitpage/service/RecruitPageService.java
+++ b/src/main/java/sopt/org/homepage/application/recruitpage/service/RecruitPageService.java
@@ -1,0 +1,51 @@
+package sopt.org.homepage.application.recruitpage.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sopt.org.homepage.application.recruitpage.dto.RecruitMainPageResponse;
+import sopt.org.homepage.corevalue.CoreValueService;
+import sopt.org.homepage.corevalue.dto.CoreValueView;
+import sopt.org.homepage.faq.FAQService;
+import sopt.org.homepage.faq.dto.FAQView;
+import sopt.org.homepage.generation.GenerationService;
+import sopt.org.homepage.generation.dto.GenerationDetailView;
+import sopt.org.homepage.member.MemberService;
+import sopt.org.homepage.part.PartService;
+import sopt.org.homepage.part.dto.PartIntroductionView;
+import sopt.org.homepage.recruitment.RecruitmentService;
+import sopt.org.homepage.recruitpartintroduction.RecruitPartIntroductionService;
+import sopt.org.homepage.recruitpartintroduction.dto.RecruitPartIntroductionView;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecruitPageService {
+    private final CoreValueService coreValueService;
+    private final FAQService faqService;
+    private final GenerationService generationService;
+    private final MemberService memberService;
+    private final PartService partService;
+    private final RecruitmentService recruitmentService;
+    private final RecruitPartIntroductionService recruitPartIntroductionService;
+
+
+    public RecruitMainPageResponse getRecruitMainPageData(){
+
+        GenerationDetailView generation = generationService.findLatest();
+        Integer generationId = generation.id();
+
+        List<CoreValueView> coreValues =
+                coreValueService.findByGeneration(generationId);
+
+        List<PartIntroductionView> partIntroductions =
+                partService.findIntroductionsByGeneration(generationId);
+
+        List<FAQView> faqs = faqService.findAll();
+
+        return RecruitMainPageResponse.from(generation, coreValues, partIntroductions, faqs);
+
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 이 PR이 해결하는 이슈 -->
Related to #229

## 📋 작업 내용 요약

<!-- 이 PR에서 무엇을 했나요? -->
지원서 메인 페이지에 필요한 데이터인 핵심 가치, 파트 소개, FAQ를 조회하는 API를 구현했습니다.

## 💡 구현 방법

<!-- 어떻게 구현했나요? 기술적 선택의 이유는? -->
기존에 Mainpage 쪽에 있던 로직을 가져와 사용했습니다. 동일한 데이터이지만 DTO는 재사용하지 않았는데, 서로 다른 요구사항에서 발생한 DTO이므로 의존성을 갖지 않게 하려는 의도입니다.



- [ ] 코드 스타일 가이드 준수
- [ ] Self Review 완료
- [ ] 테스트 코드 작성 및 통과
- [ ] 문서 업데이트 (필요 시)
- [ ] 커밋 메시지 컨벤션 준수
- [ ] 충돌(Conflict) 해결 완료
