### PR TITLE
[FEAT] 메인 페이지 데이터에 운영 기간 추가

### DIFF
--- a/src/main/java/sopt/org/homepage/application/homepage/controller/dto/MainPageResponse.java
+++ b/src/main/java/sopt/org/homepage/application/homepage/controller/dto/MainPageResponse.java
@@ -87,7 +87,10 @@ public record MainPageResponse(
             int projectCounts,
 
             @Schema(description = "스터디 수", example = "98")
-            int studyCounts
+            int studyCounts,
+
+            @Schema(description = "운영 기간", example = "37")
+            int operationPeriod
     ) {
     }
 }

--- a/src/main/java/sopt/org/homepage/application/homepage/service/HomepageQueryService.java
+++ b/src/main/java/sopt/org/homepage/application/homepage/service/HomepageQueryService.java
@@ -299,10 +299,13 @@ public class HomepageQueryService {
             // Study 개수 조회 (Crew API)
             int studyCount = crewService.getStudyCount(generationId);
 
+            final int OPERATION_PERIOD = 37;
+
             return MainPageResponse.ActivitiesRecords.builder()
                     .activitiesMemberCount((int) activitiesMemberCount)
                     .projectCounts(projectCount)
                     .studyCounts(studyCount)
+                    .operationPeriod(OPERATION_PERIOD)
                     .build();
 
         } catch (Exception e) {


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 이 PR이 해결하는 이슈 -->
Related to #248

## 📋 작업 내용 요약

<!-- 이 PR에서 무엇을 했나요? -->
메인 페이지 데이터에 운영 기간을 추가했습니다. 운영 기간은 어느 도메인에 속한다고 보기에 애매한 부분이 있어 DB에 저장하지 않고 메모리에서 상수로 관리하도록 했습니다.

### 주요 변경사항
- 

-
-

## 💡 구현 방법

<!-- 어떻게 구현했나요? 기술적 선택의 이유는? -->

## 📸 스크린샷 / 실행 결과

<!-- UI 변경이나 실행 결과가 있다면 -->

## 🧪 테스트

<!-- 어떤 테스트를 했나요? -->

### 테스트 케이스

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 추가/수정
- [ ] 수동 테스트 완료

### 테스트 시나리오

1.
2.
3.

## 🔍 리뷰 포인트

<!-- 리뷰어가 특히 봐줬으면 하는 부분 -->
- 

-

## ⚠️ 주의사항

<!-- 배포 시 주의할 점이나 Breaking Changes -->

- [ ] Breaking Change 없음
- [ ] DB 마이그레이션 필요 (있다면 설명)
- [ ] 환경 변수 추가/변경 (있다면 설명)
- [ ] 의존성 추가/변경 (있다면 설명)

## 📝 추가 메모

<!-- 기타 참고사항 -->



---

## ✅ PR 체크리스트

- [ ] 코드 스타일 가이드 준수
- [ ] Self Review 완료
- [ ] 테스트 코드 작성 및 통과
- [ ] 문서 업데이트 (필요 시)
- [ ] 커밋 메시지 컨벤션 준수
- [ ] 충돌(Conflict) 해결 완료
