### PR TITLE
[FEAT] 어드민 배포 엔드포인트 탭별 분리

### DIFF
--- a/src/main/java/sopt/org/homepage/application/admin/AdminController.java
+++ b/src/main/java/sopt/org/homepage/application/admin/AdminController.java
@@ -14,8 +14,16 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import sopt.org.homepage.application.admin.dto.AddAdminAboutRequestDto;
+import sopt.org.homepage.application.admin.dto.AddAdminAboutResponseDto;
+import sopt.org.homepage.application.admin.dto.AddAdminCommonRequestDto;
+import sopt.org.homepage.application.admin.dto.AddAdminCommonResponseDto;
 import sopt.org.homepage.application.admin.dto.AddAdminConfirmRequestDto;
 import sopt.org.homepage.application.admin.dto.AddAdminConfirmResponseDto;
+import sopt.org.homepage.application.admin.dto.AddAdminHomeRequestDto;
+import sopt.org.homepage.application.admin.dto.AddAdminHomeResponseDto;
+import sopt.org.homepage.application.admin.dto.AddAdminRecruitRequestDto;
+import sopt.org.homepage.application.admin.dto.AddAdminRecruitResponseDto;
 import sopt.org.homepage.application.admin.dto.AddAdminRequestDto;
 import sopt.org.homepage.application.admin.dto.AddAdminResponseDto;
 import sopt.org.homepage.application.admin.dto.GetAdminRequestDto;
@@ -31,24 +39,6 @@ import sopt.org.homepage.global.common.constants.SecurityConstants;
 public class AdminController {
     private final AdminService adminService;
 
-    @Operation(summary = "어드민 메인 데이터 배포", description = "어드민 메인 데이터를 배포합니다")
-    @PostMapping("")
-    public ResponseEntity<AddAdminResponseDto> addMain(
-            @RequestBody @Valid AddAdminRequestDto addAdminRequestDto
-    ) {
-        AddAdminResponseDto result = adminService.addMainData(addAdminRequestDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(result);
-    }
-
-    @Operation(summary = "어드민 메인 데이터 배포 확인", description = "어드민 메인 데이터 배포를 확인합니다")
-    @PostMapping("confirm")
-    public ResponseEntity<AddAdminConfirmResponseDto> addMainConfirm(
-            @RequestBody @Valid AddAdminConfirmRequestDto addMainRequestDto
-    ) {
-        AddAdminConfirmResponseDto result = adminService.addMainDataConfirm(addMainRequestDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(result);
-    }
-
     @Operation(summary = "어드민 메인 데이터 조회", description = "어드민 메인 데이터를 조회합니다")
     @GetMapping("")
     public ResponseEntity<GetAdminResponseDto> getMain(
@@ -56,6 +46,86 @@ public class AdminController {
     ) {
         GetAdminResponseDto result = adminService.getMain(getAdminRequestDto);
         return ResponseEntity.status(HttpStatus.OK).body(result);
+    }
+
+    // ===== 탭별 배포 - 공통 =====
+
+    @Operation(summary = "공통 탭 배포", description = "기수 정보, 브랜딩 컬러, 메인 버튼, 모집 일정을 캐시에 저장합니다. 이미지가 없으므로 응답 즉시 2단계(confirm)를 호출해도 됩니다.")
+    @PostMapping("common")
+    public ResponseEntity<AddAdminCommonResponseDto> addCommon(
+            @RequestBody @Valid AddAdminCommonRequestDto request
+    ) {
+        AddAdminCommonResponseDto result = adminService.addCommonData(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
+    }
+
+    @Operation(summary = "공통 탭 배포 확정", description = "캐시에 저장된 공통 탭 데이터를 DB에 반영합니다. 공통 탭은 반드시 다른 탭보다 먼저 배포해야 합니다.")
+    @PostMapping("common/confirm")
+    public ResponseEntity<AddAdminConfirmResponseDto> addCommonConfirm(
+            @RequestBody @Valid AddAdminConfirmRequestDto request
+    ) {
+        AddAdminConfirmResponseDto result = adminService.addCommonDataConfirm(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
+    }
+
+    // ===== 탭별 배포 - 홈 =====
+
+    @Operation(summary = "홈 탭 배포", description = "홈 헤더 이미지 Presigned URL을 발급하고 리뷰/최신소식을 캐시에 저장합니다. 응답의 Presigned URL로 이미지 업로드 후 2단계를 호출하세요.")
+    @PostMapping("home")
+    public ResponseEntity<AddAdminHomeResponseDto> addHome(
+            @RequestBody @Valid AddAdminHomeRequestDto request
+    ) {
+        AddAdminHomeResponseDto result = adminService.addHomeData(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
+    }
+
+    @Operation(summary = "홈 탭 배포 확정", description = "이미지 업로드 완료 후 캐시 데이터를 DB에 반영합니다. 공통 탭 배포 이후에 호출해야 합니다.")
+    @PostMapping("home/confirm")
+    public ResponseEntity<AddAdminConfirmResponseDto> addHomeConfirm(
+            @RequestBody @Valid AddAdminConfirmRequestDto request
+    ) {
+        AddAdminConfirmResponseDto result = adminService.addHomeDataConfirm(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
+    }
+
+    // ===== 탭별 배포 - 소개 =====
+
+    @Operation(summary = "소개 탭 배포", description = "소개 헤더/핵심가치/임원진 이미지 Presigned URL을 발급하고 전체 일정을 캐시에 저장합니다. 응답의 Presigned URL로 이미지 업로드 후 2단계를 호출하세요.")
+    @PostMapping("about")
+    public ResponseEntity<AddAdminAboutResponseDto> addAbout(
+            @RequestBody @Valid AddAdminAboutRequestDto request
+    ) {
+        AddAdminAboutResponseDto result = adminService.addAboutData(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
+    }
+
+    @Operation(summary = "소개 탭 배포 확정", description = "이미지 업로드 완료 후 캐시 데이터를 DB에 반영합니다. 공통 탭 배포 이후에 호출해야 합니다.")
+    @PostMapping("about/confirm")
+    public ResponseEntity<AddAdminConfirmResponseDto> addAboutConfirm(
+            @RequestBody @Valid AddAdminConfirmRequestDto request
+    ) {
+        AddAdminConfirmResponseDto result = adminService.addAboutDataConfirm(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
+    }
+
+    // ===== 탭별 배포 - 모집안내 =====
+
+    @Operation(summary = "모집안내 탭 배포", description = "모집 헤더 이미지 Presigned URL을 발급하고 파트별 소개/커리큘럼/FAQ를 캐시에 저장합니다. 응답의 Presigned URL로 이미지 업로드 후 2단계를 호출하세요.")
+    @PostMapping("recruit")
+    public ResponseEntity<AddAdminRecruitResponseDto> addRecruit(
+            @RequestBody @Valid AddAdminRecruitRequestDto request
+    ) {
+        AddAdminRecruitResponseDto result = adminService.addRecruitData(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
+    }
+
+    @Operation(summary = "모집안내 탭 배포 확정", description = "이미지 업로드 완료 후 캐시 데이터를 DB에 반영합니다. 공통 탭 배포 이후에 호출해야 합니다.")
+    @PostMapping("recruit/confirm")
+    public ResponseEntity<AddAdminConfirmResponseDto> addRecruitConfirm(
+            @RequestBody @Valid AddAdminConfirmRequestDto request
+    ) {
+        AddAdminConfirmResponseDto result = adminService.addRecruitDataConfirm(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
     }
 }
 

--- a/src/main/java/sopt/org/homepage/application/admin/dto/AddAdminAboutRequestDto.java
+++ b/src/main/java/sopt/org/homepage/application/admin/dto/AddAdminAboutRequestDto.java
@@ -22,7 +22,7 @@ public class AddAdminAboutRequestDto {
     @Schema(description = "기수", requiredMode = Schema.RequiredMode.REQUIRED, example = "36")
     @NotNull(message = "generation must not be null")
     @Positive(message = "generation must be a positive number")
-    private int generation;
+    private Integer generation;
 
     @Schema(description = "헤더 이미지 파일명", requiredMode = Schema.RequiredMode.REQUIRED, example = "header.png")
     @NotEmpty(message = "headerImageFileName must not be empty")

--- a/src/main/java/sopt/org/homepage/application/admin/dto/AddAdminAboutRequestDto.java
+++ b/src/main/java/sopt/org/homepage/application/admin/dto/AddAdminAboutRequestDto.java
@@ -1,0 +1,42 @@
+package sopt.org.homepage.application.admin.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import sopt.org.homepage.application.admin.dto.request.main.activityschedule.AddAdminActivityScheduleRequestDto;
+import sopt.org.homepage.application.admin.dto.request.main.core.AddAdminCoreValueRequestDto;
+import sopt.org.homepage.application.admin.dto.request.main.member.AddAdminMemberRequestDto;
+
+@Validated
+@Schema(description = "어드민 소개 탭 배포")
+@Getter
+@NoArgsConstructor
+public class AddAdminAboutRequestDto {
+
+    @Schema(description = "기수", requiredMode = Schema.RequiredMode.REQUIRED, example = "36")
+    @NotNull(message = "generation must not be null")
+    @Positive(message = "generation must be a positive number")
+    private int generation;
+
+    @Schema(description = "헤더 이미지 파일명", requiredMode = Schema.RequiredMode.REQUIRED, example = "header.png")
+    @NotEmpty(message = "headerImageFileName must not be empty")
+    private String headerImageFileName;
+
+    @Schema(description = "핵심가치 목록")
+    @Valid
+    private List<AddAdminCoreValueRequestDto> coreValue;
+
+    @Schema(description = "임원진 목록")
+    @Valid
+    private List<AddAdminMemberRequestDto> member;
+
+    @Schema(description = "전체 일정 목록")
+    @Valid
+    private List<AddAdminActivityScheduleRequestDto> activitySchedule;
+}

--- a/src/main/java/sopt/org/homepage/application/admin/dto/AddAdminAboutResponseDto.java
+++ b/src/main/java/sopt/org/homepage/application/admin/dto/AddAdminAboutResponseDto.java
@@ -1,0 +1,28 @@
+package sopt.org.homepage.application.admin.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import sopt.org.homepage.application.admin.dto.response.main.core.AddAdminCoreValueResponseRecordDto;
+import sopt.org.homepage.application.admin.dto.response.main.member.AddAdminMemberResponseRecordDto;
+
+@Schema(description = "어드민 소개 탭 배포 응답 (S3 PresignedUrl 포함)")
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class AddAdminAboutResponseDto {
+
+    @Schema(description = "기수", requiredMode = Schema.RequiredMode.REQUIRED, example = "36")
+    private final int generation;
+
+    @Schema(description = "소개 헤더 이미지 S3 PresignedUrl", requiredMode = Schema.RequiredMode.REQUIRED)
+    private final String headerImage;
+
+    @Schema(description = "핵심가치 이미지 S3 PresignedUrl 목록")
+    private final List<AddAdminCoreValueResponseRecordDto> coreValues;
+
+    @Schema(description = "임원진 프로필 이미지 S3 PresignedUrl 목록")
+    private final List<AddAdminMemberResponseRecordDto> members;
+}

--- a/src/main/java/sopt/org/homepage/application/admin/dto/AddAdminCommonRequestDto.java
+++ b/src/main/java/sopt/org/homepage/application/admin/dto/AddAdminCommonRequestDto.java
@@ -1,0 +1,44 @@
+package sopt.org.homepage.application.admin.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import sopt.org.homepage.application.admin.dto.request.main.branding.AddAdminBrandingColorRequestDto;
+import sopt.org.homepage.application.admin.dto.request.main.button.AddAdminMainButtonRequestDto;
+import sopt.org.homepage.application.admin.dto.request.main.recruit.schedule.AddAdminRecruitScheduleRequestDto;
+
+@Validated
+@Schema(description = "어드민 공통 탭 배포")
+@Getter
+@NoArgsConstructor
+public class AddAdminCommonRequestDto {
+
+    @Schema(description = "기수", requiredMode = Schema.RequiredMode.REQUIRED, example = "36")
+    @NotNull(message = "generation must not be null")
+    @Positive(message = "generation must be a positive number")
+    private int generation;
+
+    @Schema(description = "기수명", requiredMode = Schema.RequiredMode.REQUIRED, example = "SOPT")
+    @NotEmpty(message = "name must not be empty")
+    private String name;
+
+    @Schema(description = "모집 일정")
+    @Valid
+    private List<AddAdminRecruitScheduleRequestDto> recruitSchedule;
+
+    @Schema(description = "브랜딩 컬러", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull(message = "brandingColor must not be null")
+    @Valid
+    private AddAdminBrandingColorRequestDto brandingColor;
+
+    @Schema(description = "메인 버튼", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull(message = "mainButton must not be null")
+    @Valid
+    private AddAdminMainButtonRequestDto mainButton;
+}

--- a/src/main/java/sopt/org/homepage/application/admin/dto/AddAdminCommonRequestDto.java
+++ b/src/main/java/sopt/org/homepage/application/admin/dto/AddAdminCommonRequestDto.java
@@ -22,7 +22,7 @@ public class AddAdminCommonRequestDto {
     @Schema(description = "기수", requiredMode = Schema.RequiredMode.REQUIRED, example = "36")
     @NotNull(message = "generation must not be null")
     @Positive(message = "generation must be a positive number")
-    private int generation;
+    private Integer generation;
 
     @Schema(description = "기수명", requiredMode = Schema.RequiredMode.REQUIRED, example = "SOPT")
     @NotEmpty(message = "name must not be empty")

--- a/src/main/java/sopt/org/homepage/application/admin/dto/AddAdminCommonResponseDto.java
+++ b/src/main/java/sopt/org/homepage/application/admin/dto/AddAdminCommonResponseDto.java
@@ -1,0 +1,16 @@
+package sopt.org.homepage.application.admin.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Schema(description = "어드민 공통 탭 배포 응답 (이미지 없음)")
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class AddAdminCommonResponseDto {
+
+    @Schema(description = "기수", requiredMode = Schema.RequiredMode.REQUIRED, example = "36")
+    private final int generation;
+}

--- a/src/main/java/sopt/org/homepage/application/admin/dto/AddAdminHomeRequestDto.java
+++ b/src/main/java/sopt/org/homepage/application/admin/dto/AddAdminHomeRequestDto.java
@@ -21,7 +21,7 @@ public class AddAdminHomeRequestDto {
     @Schema(description = "기수", requiredMode = Schema.RequiredMode.REQUIRED, example = "36")
     @NotNull(message = "generation must not be null")
     @Positive(message = "generation must be a positive number")
-    private int generation;
+    private Integer generation;
 
     @Schema(description = "홈 헤더 이미지 파일명", requiredMode = Schema.RequiredMode.REQUIRED, example = "home_header.png")
     @NotEmpty(message = "homeHeaderImageFileName must not be empty")

--- a/src/main/java/sopt/org/homepage/application/admin/dto/AddAdminHomeRequestDto.java
+++ b/src/main/java/sopt/org/homepage/application/admin/dto/AddAdminHomeRequestDto.java
@@ -1,0 +1,37 @@
+package sopt.org.homepage.application.admin.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import sopt.org.homepage.application.admin.dto.request.main.news.AddAdminNewsRequestDto;
+import sopt.org.homepage.application.admin.dto.request.main.review.AddAdminReviewRequestDto;
+
+@Validated
+@Schema(description = "어드민 홈 탭 배포")
+@Getter
+@NoArgsConstructor
+public class AddAdminHomeRequestDto {
+
+    @Schema(description = "기수", requiredMode = Schema.RequiredMode.REQUIRED, example = "36")
+    @NotNull(message = "generation must not be null")
+    @Positive(message = "generation must be a positive number")
+    private int generation;
+
+    @Schema(description = "홈 헤더 이미지 파일명", requiredMode = Schema.RequiredMode.REQUIRED, example = "home_header.png")
+    @NotEmpty(message = "homeHeaderImageFileName must not be empty")
+    private String homeHeaderImageFileName;
+
+    @Schema(description = "리뷰 목록")
+    @Valid
+    private List<AddAdminReviewRequestDto> review;
+
+    @Schema(description = "최신소식 목록")
+    @Valid
+    private List<AddAdminNewsRequestDto> news;
+}

--- a/src/main/java/sopt/org/homepage/application/admin/dto/AddAdminHomeResponseDto.java
+++ b/src/main/java/sopt/org/homepage/application/admin/dto/AddAdminHomeResponseDto.java
@@ -1,0 +1,24 @@
+package sopt.org.homepage.application.admin.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import sopt.org.homepage.application.admin.dto.response.main.news.AddAdminNewsResponseRecordDto;
+
+@Schema(description = "어드민 홈 탭 배포 응답 (S3 PresignedUrl 포함)")
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class AddAdminHomeResponseDto {
+
+    @Schema(description = "기수", requiredMode = Schema.RequiredMode.REQUIRED, example = "36")
+    private final int generation;
+
+    @Schema(description = "홈 헤더 이미지 S3 PresignedUrl", requiredMode = Schema.RequiredMode.REQUIRED)
+    private final String homeHeaderImage;
+
+    @Schema(description = "최신소식 이미지 S3 PresignedUrl 목록")
+    private final List<AddAdminNewsResponseRecordDto> news;
+}

--- a/src/main/java/sopt/org/homepage/application/admin/dto/AddAdminRecruitRequestDto.java
+++ b/src/main/java/sopt/org/homepage/application/admin/dto/AddAdminRecruitRequestDto.java
@@ -1,0 +1,47 @@
+package sopt.org.homepage.application.admin.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import sopt.org.homepage.application.admin.dto.request.main.curriculum.AddAdminPartCurriculumRequestDto;
+import sopt.org.homepage.application.admin.dto.request.main.introduction.AddAdminPartIntroductionRequestDto;
+import sopt.org.homepage.application.admin.dto.request.main.recruit.curriculum.AddAdminRecruitPartCurriculumRequestDto;
+import sopt.org.homepage.application.admin.dto.request.main.recruit.question.AddAdminRecruitQuestionRequestDto;
+
+@Validated
+@Schema(description = "어드민 모집안내 탭 배포")
+@Getter
+@NoArgsConstructor
+public class AddAdminRecruitRequestDto {
+
+    @Schema(description = "기수", requiredMode = Schema.RequiredMode.REQUIRED, example = "36")
+    @NotNull(message = "generation must not be null")
+    @Positive(message = "generation must be a positive number")
+    private int generation;
+
+    @Schema(description = "지원하기 헤더 이미지 파일명", requiredMode = Schema.RequiredMode.REQUIRED, example = "recruit_header.png")
+    @NotEmpty(message = "recruitHeaderImageFileName must not be empty")
+    private String recruitHeaderImageFileName;
+
+    @Schema(description = "파트별 소개 목록 (한 줄 소개 + 이런 걸 배워요)")
+    @Valid
+    private List<AddAdminPartIntroductionRequestDto> partIntroduction;
+
+    @Schema(description = "파트별 커리큘럼 목록 (이런 걸 배워요 - 주차별)")
+    @Valid
+    private List<AddAdminPartCurriculumRequestDto> partCurriculum;
+
+    @Schema(description = "파트별 상세 소개 목록 (파트 소개 + 이런 분이면 좋아요)")
+    @Valid
+    private List<AddAdminRecruitPartCurriculumRequestDto> recruitPartCurriculum;
+
+    @Schema(description = "자주 묻는 질문 목록")
+    @Valid
+    private List<AddAdminRecruitQuestionRequestDto> recruitQuestion;
+}

--- a/src/main/java/sopt/org/homepage/application/admin/dto/AddAdminRecruitRequestDto.java
+++ b/src/main/java/sopt/org/homepage/application/admin/dto/AddAdminRecruitRequestDto.java
@@ -23,7 +23,7 @@ public class AddAdminRecruitRequestDto {
     @Schema(description = "기수", requiredMode = Schema.RequiredMode.REQUIRED, example = "36")
     @NotNull(message = "generation must not be null")
     @Positive(message = "generation must be a positive number")
-    private int generation;
+    private Integer generation;
 
     @Schema(description = "지원하기 헤더 이미지 파일명", requiredMode = Schema.RequiredMode.REQUIRED, example = "recruit_header.png")
     @NotEmpty(message = "recruitHeaderImageFileName must not be empty")

--- a/src/main/java/sopt/org/homepage/application/admin/dto/AddAdminRecruitResponseDto.java
+++ b/src/main/java/sopt/org/homepage/application/admin/dto/AddAdminRecruitResponseDto.java
@@ -1,0 +1,19 @@
+package sopt.org.homepage.application.admin.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Schema(description = "어드민 모집안내 탭 배포 응답 (S3 PresignedUrl 포함)")
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class AddAdminRecruitResponseDto {
+
+    @Schema(description = "기수", requiredMode = Schema.RequiredMode.REQUIRED, example = "36")
+    private final int generation;
+
+    @Schema(description = "모집안내 헤더 이미지 S3 PresignedUrl", requiredMode = Schema.RequiredMode.REQUIRED)
+    private final String recruitHeaderImage;
+}

--- a/src/main/java/sopt/org/homepage/application/admin/dto/response/main/news/AddAdminNewsResponseRecordDto.java
+++ b/src/main/java/sopt/org/homepage/application/admin/dto/response/main/news/AddAdminNewsResponseRecordDto.java
@@ -1,0 +1,12 @@
+package sopt.org.homepage.application.admin.dto.response.main.news;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "최신소식 이미지 S3 PresignedUrl 정보")
+@Builder
+public record AddAdminNewsResponseRecordDto(
+        @Schema(description = "뉴스 제목", requiredMode = Schema.RequiredMode.REQUIRED) String title,
+        @Schema(description = "뉴스 이미지 PresignedUrl", requiredMode = Schema.RequiredMode.REQUIRED) String imagePresignedUrl
+) {
+}

--- a/src/main/java/sopt/org/homepage/application/admin/service/AdminService.java
+++ b/src/main/java/sopt/org/homepage/application/admin/service/AdminService.java
@@ -17,10 +17,11 @@ import sopt.org.homepage.application.admin.dto.GetAdminResponseDto;
 
 public interface AdminService {
 
-    // ===== 기존 통합 배포 (하위 호환) =====
+    GetAdminResponseDto getMain(GetAdminRequestDto getAdminRequestDto);
+
+    // ===== 기존 통합 배포 =====
     AddAdminResponseDto addMainData(AddAdminRequestDto addAdminRequestDto);
     AddAdminConfirmResponseDto addMainDataConfirm(AddAdminConfirmRequestDto addAdminConfirmRequestDto);
-    GetAdminResponseDto getMain(GetAdminRequestDto getAdminRequestDto);
 
     // ===== 탭별 배포 - 공통 =====
     AddAdminCommonResponseDto addCommonData(AddAdminCommonRequestDto request);

--- a/src/main/java/sopt/org/homepage/application/admin/service/AdminService.java
+++ b/src/main/java/sopt/org/homepage/application/admin/service/AdminService.java
@@ -1,16 +1,40 @@
 package sopt.org.homepage.application.admin.service;
 
+import sopt.org.homepage.application.admin.dto.AddAdminAboutRequestDto;
+import sopt.org.homepage.application.admin.dto.AddAdminAboutResponseDto;
+import sopt.org.homepage.application.admin.dto.AddAdminCommonRequestDto;
+import sopt.org.homepage.application.admin.dto.AddAdminCommonResponseDto;
 import sopt.org.homepage.application.admin.dto.AddAdminConfirmRequestDto;
 import sopt.org.homepage.application.admin.dto.AddAdminConfirmResponseDto;
+import sopt.org.homepage.application.admin.dto.AddAdminHomeRequestDto;
+import sopt.org.homepage.application.admin.dto.AddAdminHomeResponseDto;
+import sopt.org.homepage.application.admin.dto.AddAdminRecruitRequestDto;
+import sopt.org.homepage.application.admin.dto.AddAdminRecruitResponseDto;
 import sopt.org.homepage.application.admin.dto.AddAdminRequestDto;
 import sopt.org.homepage.application.admin.dto.AddAdminResponseDto;
 import sopt.org.homepage.application.admin.dto.GetAdminRequestDto;
 import sopt.org.homepage.application.admin.dto.GetAdminResponseDto;
 
 public interface AdminService {
+
+    // ===== 기존 통합 배포 (하위 호환) =====
     AddAdminResponseDto addMainData(AddAdminRequestDto addAdminRequestDto);
-
     AddAdminConfirmResponseDto addMainDataConfirm(AddAdminConfirmRequestDto addAdminConfirmRequestDto);
-
     GetAdminResponseDto getMain(GetAdminRequestDto getAdminRequestDto);
+
+    // ===== 탭별 배포 - 공통 =====
+    AddAdminCommonResponseDto addCommonData(AddAdminCommonRequestDto request);
+    AddAdminConfirmResponseDto addCommonDataConfirm(AddAdminConfirmRequestDto request);
+
+    // ===== 탭별 배포 - 홈 =====
+    AddAdminHomeResponseDto addHomeData(AddAdminHomeRequestDto request);
+    AddAdminConfirmResponseDto addHomeDataConfirm(AddAdminConfirmRequestDto request);
+
+    // ===== 탭별 배포 - 소개 =====
+    AddAdminAboutResponseDto addAboutData(AddAdminAboutRequestDto request);
+    AddAdminConfirmResponseDto addAboutDataConfirm(AddAdminConfirmRequestDto request);
+
+    // ===== 탭별 배포 - 모집안내 =====
+    AddAdminRecruitResponseDto addRecruitData(AddAdminRecruitRequestDto request);
+    AddAdminConfirmResponseDto addRecruitDataConfirm(AddAdminConfirmRequestDto request);
 }

--- a/src/main/java/sopt/org/homepage/application/admin/service/AdminServiceImpl.java
+++ b/src/main/java/sopt/org/homepage/application/admin/service/AdminServiceImpl.java
@@ -534,7 +534,7 @@ public class AdminServiceImpl implements AdminService {
 
         generationService.createOrUpdateCommon(generationId, cachedData.getName(), brandingColor, mainButton);
 
-        if (cachedData.getRecruitSchedules() != null && !cachedData.getRecruitSchedules().isEmpty()) {
+        if (cachedData.getRecruitSchedules() != null) {
             recruitmentService.bulkCreate(
                     BulkCreateRecruitmentsCommand.builder()
                             .generationId(generationId)
@@ -582,8 +582,9 @@ public class AdminServiceImpl implements AdminService {
                 request.getHomeHeaderImageFileName(), baseDir);
         cachedData.setHomeHeaderImageUrl(homeHeaderImageUrl);
 
-        List<CachedAdminData.NewsData> newsDataList = new ArrayList<>();
+        List<CachedAdminData.NewsData> newsDataList = null;
         if (request.getNews() != null) {
+            newsDataList = new ArrayList<>();
             for (var news : request.getNews()) {
                 String newsImageUrl = s3Service.generatePresignedUrl(
                         news.getImageFileName(), baseDir + "news/");
@@ -593,8 +594,8 @@ public class AdminServiceImpl implements AdminService {
                         .imageUrl(newsImageUrl)
                         .build());
             }
+            cachedData.setNews(newsDataList);
         }
-        cachedData.setNews(newsDataList);
 
         if (request.getReview() != null) {
             cachedData.setReviews(new ArrayList<>(request.getReview()));
@@ -606,12 +607,14 @@ public class AdminServiceImpl implements AdminService {
         return AddAdminHomeResponseDto.builder()
                 .generation(generationId)
                 .homeHeaderImage(homeHeaderImageUrl)
-                .news(newsDataList.stream()
-                        .map(n -> AddAdminNewsResponseRecordDto.builder()
-                                .title(n.getTitle())
-                                .imagePresignedUrl(n.getImageUrl())
-                                .build())
-                        .toList())
+                .news(newsDataList != null
+                        ? newsDataList.stream()
+                                .map(n -> AddAdminNewsResponseRecordDto.builder()
+                                        .title(n.getTitle())
+                                        .imagePresignedUrl(n.getImageUrl())
+                                        .build())
+                                .toList()
+                        : null)
                 .build();
     }
 
@@ -633,7 +636,7 @@ public class AdminServiceImpl implements AdminService {
         String homeHeaderImageUrl = s3Service.getOriginalUrl(cachedData.getHomeHeaderImageUrl());
         generationService.updateHomeHeaderImage(generationId, homeHeaderImageUrl);
 
-        if (cachedData.getNews() != null && !cachedData.getNews().isEmpty()) {
+        if (cachedData.getNews() != null) {
             newsService.bulkCreate(
                     BulkCreateNewsCommand.builder()
                             .news(cachedData.getNews().stream()
@@ -647,7 +650,7 @@ public class AdminServiceImpl implements AdminService {
             );
         }
 
-        if (cachedData.getReviews() != null && !cachedData.getReviews().isEmpty()) {
+        if (cachedData.getReviews() != null) {
             homepageReviewService.bulkCreate(
                     BulkCreateHomepageReviewsCommand.builder()
                             .reviews(cachedData.getReviews().stream()
@@ -688,8 +691,9 @@ public class AdminServiceImpl implements AdminService {
                 request.getHeaderImageFileName(), baseDir);
         cachedData.setHeaderImageUrl(headerImageUrl);
 
-        List<CachedAdminData.CoreValueData> coreValueDataList = new ArrayList<>();
+        List<CachedAdminData.CoreValueData> coreValueDataList = null;
         if (request.getCoreValue() != null) {
+            coreValueDataList = new ArrayList<>();
             for (var cv : request.getCoreValue()) {
                 String imageUrl = s3Service.generatePresignedUrl(
                         cv.getImageFileName(), baseDir + "coreValue/");
@@ -700,11 +704,12 @@ public class AdminServiceImpl implements AdminService {
                         .imageUrl(imageUrl)
                         .build());
             }
+            cachedData.setCoreValues(coreValueDataList);
         }
-        cachedData.setCoreValues(coreValueDataList);
 
-        List<CachedAdminData.MemberData> memberDataList = new ArrayList<>();
+        List<CachedAdminData.MemberData> memberDataList = null;
         if (request.getMember() != null) {
+            memberDataList = new ArrayList<>();
             for (var member : request.getMember()) {
                 String profileImageUrl = s3Service.generatePresignedUrl(
                         member.getProfileImageFileName(), baseDir + "member/");
@@ -720,8 +725,8 @@ public class AdminServiceImpl implements AdminService {
                         .snsBehance(member.getSns() != null ? member.getSns().getBehance() : null)
                         .build());
             }
+            cachedData.setMembers(memberDataList);
         }
-        cachedData.setMembers(memberDataList);
 
         if (request.getActivitySchedule() != null) {
             cachedData.setActivitySchedules(new ArrayList<>(request.getActivitySchedule()));
@@ -733,19 +738,23 @@ public class AdminServiceImpl implements AdminService {
         return AddAdminAboutResponseDto.builder()
                 .generation(generationId)
                 .headerImage(headerImageUrl)
-                .coreValues(coreValueDataList.stream()
-                        .map(cv -> AddAdminCoreValueResponseRecordDto.builder()
-                                .value(cv.getValue())
-                                .image(cv.getImageUrl())
-                                .build())
-                        .toList())
-                .members(memberDataList.stream()
-                        .map(m -> AddAdminMemberResponseRecordDto.builder()
-                                .role(m.getRole())
-                                .name(m.getName())
-                                .profileImage(m.getProfileImageUrl())
-                                .build())
-                        .toList())
+                .coreValues(coreValueDataList != null
+                        ? coreValueDataList.stream()
+                                .map(cv -> AddAdminCoreValueResponseRecordDto.builder()
+                                        .value(cv.getValue())
+                                        .image(cv.getImageUrl())
+                                        .build())
+                                .toList()
+                        : null)
+                .members(memberDataList != null
+                        ? memberDataList.stream()
+                                .map(m -> AddAdminMemberResponseRecordDto.builder()
+                                        .role(m.getRole())
+                                        .name(m.getName())
+                                        .profileImage(m.getProfileImageUrl())
+                                        .build())
+                                .toList()
+                        : null)
                 .build();
     }
 
@@ -767,7 +776,7 @@ public class AdminServiceImpl implements AdminService {
         String headerImageUrl = s3Service.getOriginalUrl(cachedData.getHeaderImageUrl());
         generationService.updateHeaderImage(generationId, headerImageUrl);
 
-        if (cachedData.getCoreValues() != null && !cachedData.getCoreValues().isEmpty()) {
+        if (cachedData.getCoreValues() != null) {
             List<String> coreValueImageUrls = cachedData.getCoreValues().stream()
                     .map(cv -> s3Service.getOriginalUrl(cv.getImageUrl()))
                     .toList();
@@ -791,7 +800,7 @@ public class AdminServiceImpl implements AdminService {
             );
         }
 
-        if (cachedData.getMembers() != null && !cachedData.getMembers().isEmpty()) {
+        if (cachedData.getMembers() != null) {
             List<String> memberProfileImageUrls = cachedData.getMembers().stream()
                     .map(m -> s3Service.getOriginalUrl(m.getProfileImageUrl()))
                     .toList();
@@ -821,7 +830,7 @@ public class AdminServiceImpl implements AdminService {
             );
         }
 
-        if (cachedData.getActivitySchedules() != null && !cachedData.getActivitySchedules().isEmpty()) {
+        if (cachedData.getActivitySchedules() != null) {
             activityScheduleService.bulkCreate(
                     BulkCreateActivitySchedulesCommand.builder()
                             .generationId(generationId)
@@ -927,7 +936,7 @@ public class AdminServiceImpl implements AdminService {
             );
         }
 
-        if (cachedData.getRecruitPartCurriculums() != null && !cachedData.getRecruitPartCurriculums().isEmpty()) {
+        if (cachedData.getRecruitPartCurriculums() != null) {
             recruitPartIntroductionService.bulkCreate(
                     BulkCreateRecruitPartIntroductionsCommand.builder()
                             .generationId(generationId)
@@ -945,7 +954,7 @@ public class AdminServiceImpl implements AdminService {
             );
         }
 
-        if (cachedData.getRecruitQuestions() != null && !cachedData.getRecruitQuestions().isEmpty()) {
+        if (cachedData.getRecruitQuestions() != null) {
             faqService.bulkCreate(
                     BulkCreateFAQsCommand.builder()
                             .faqs(cachedData.getRecruitQuestions().stream()

--- a/src/main/java/sopt/org/homepage/application/admin/service/AdminServiceImpl.java
+++ b/src/main/java/sopt/org/homepage/application/admin/service/AdminServiceImpl.java
@@ -6,12 +6,21 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import sopt.org.homepage.application.admin.dto.AddAdminAboutRequestDto;
+import sopt.org.homepage.application.admin.dto.AddAdminAboutResponseDto;
+import sopt.org.homepage.application.admin.dto.AddAdminCommonRequestDto;
+import sopt.org.homepage.application.admin.dto.AddAdminCommonResponseDto;
 import sopt.org.homepage.application.admin.dto.AddAdminConfirmRequestDto;
 import sopt.org.homepage.application.admin.dto.AddAdminConfirmResponseDto;
+import sopt.org.homepage.application.admin.dto.AddAdminHomeRequestDto;
+import sopt.org.homepage.application.admin.dto.AddAdminHomeResponseDto;
+import sopt.org.homepage.application.admin.dto.AddAdminRecruitRequestDto;
+import sopt.org.homepage.application.admin.dto.AddAdminRecruitResponseDto;
 import sopt.org.homepage.application.admin.dto.AddAdminRequestDto;
 import sopt.org.homepage.application.admin.dto.AddAdminResponseDto;
 import sopt.org.homepage.application.admin.dto.GetAdminRequestDto;
 import sopt.org.homepage.application.admin.dto.GetAdminResponseDto;
+import sopt.org.homepage.application.admin.dto.response.main.news.AddAdminNewsResponseRecordDto;
 import sopt.org.homepage.application.admin.dto.request.main.curriculum.AddAdminPartCurriculumRequestDto;
 import sopt.org.homepage.application.admin.dto.request.main.introduction.AddAdminPartIntroductionRequestDto;
 import sopt.org.homepage.application.admin.dto.request.main.recruit.curriculum.AddAdminRecruitPartCurriculumRequestDto;
@@ -20,6 +29,8 @@ import sopt.org.homepage.application.admin.dto.request.main.recruit.schedule.Add
 import sopt.org.homepage.activityschedule.ActivitySchedule;
 import sopt.org.homepage.activityschedule.ActivityScheduleService;
 import sopt.org.homepage.activityschedule.dto.BulkCreateActivitySchedulesCommand;
+import sopt.org.homepage.generation.vo.BrandingColor;
+import sopt.org.homepage.generation.vo.MainButton;
 import sopt.org.homepage.application.admin.dto.request.main.activityschedule.AddAdminActivityScheduleRequestDto;
 import sopt.org.homepage.application.admin.dto.request.main.review.AddAdminReviewRequestDto;
 import sopt.org.homepage.application.admin.dto.response.main.activityschedule.GetAdminActivityScheduleResponseRecordDto;
@@ -454,6 +465,524 @@ public class AdminServiceImpl implements AdminService {
                 .build();
     }
 
+    // =========================================================
+    // 탭별 배포 - 공통 탭
+    // =========================================================
+
+    @Override
+    @Transactional
+    public AddAdminCommonResponseDto addCommonData(AddAdminCommonRequestDto request) {
+        log.info("공통 탭 배포 1단계 - generation={}", request.getGeneration());
+
+        Integer generationId = request.getGeneration();
+
+        CachedCommonData cachedData = new CachedCommonData();
+        cachedData.setGenerationId(generationId);
+        cachedData.setName(request.getName());
+
+        var bc = request.getBrandingColor();
+        cachedData.setBrandingColorMain(bc.getMain());
+        cachedData.setBrandingColorLow(bc.getLow());
+        cachedData.setBrandingColorHigh(bc.getHigh());
+        cachedData.setBrandingColorPoint(bc.getPoint());
+
+        var mb = request.getMainButton();
+        cachedData.setMainButtonText(mb.getText());
+        cachedData.setMainButtonKeyColor(mb.getKeyColor());
+        cachedData.setMainButtonSubColor(mb.getSubColor());
+
+        if (request.getRecruitSchedule() != null) {
+            cachedData.setRecruitSchedules(new ArrayList<>(request.getRecruitSchedule()));
+        }
+
+        cacheService.put(CacheType.ADMIN_MAIN_DATA, "common_" + generationId, cachedData);
+        log.info("공통 탭 캐시 저장 완료 - generation={}", generationId);
+
+        return AddAdminCommonResponseDto.builder()
+                .generation(generationId)
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public AddAdminConfirmResponseDto addCommonDataConfirm(AddAdminConfirmRequestDto request) {
+        log.info("공통 탭 배포 2단계 - generation={}", request.getGeneration());
+
+        Integer generationId = request.getGeneration();
+
+        CachedCommonData cachedData = cacheService.get(
+                CacheType.ADMIN_MAIN_DATA, "common_" + generationId, CachedCommonData.class);
+
+        if (cachedData == null) {
+            throw new ClientBadRequestException(
+                    "공통 탭 캐시 데이터 없음. 배포 1단계를 먼저 호출하세요. generation=" + generationId);
+        }
+
+        // BrandingColor: VO는 # 없는 6자리 hex 요구 → # 제거 후 전달
+        BrandingColor brandingColor = BrandingColor.builder()
+                .main(stripHash(cachedData.getBrandingColorMain()))
+                .sub(stripHash(cachedData.getBrandingColorLow()))
+                .point(stripHash(cachedData.getBrandingColorHigh()))
+                .background(stripHash(cachedData.getBrandingColorPoint()))
+                .build();
+
+        MainButton mainButton = MainButton.builder()
+                .text(cachedData.getMainButtonText())
+                .keyColor(cachedData.getMainButtonKeyColor())
+                .subColor(cachedData.getMainButtonSubColor())
+                .build();
+
+        generationService.createOrUpdateCommon(generationId, cachedData.getName(), brandingColor, mainButton);
+
+        if (cachedData.getRecruitSchedules() != null && !cachedData.getRecruitSchedules().isEmpty()) {
+            recruitmentService.bulkCreate(
+                    BulkCreateRecruitmentsCommand.builder()
+                            .generationId(generationId)
+                            .recruitments(cachedData.getRecruitSchedules().stream()
+                                    .map(rs -> BulkCreateRecruitmentsCommand.RecruitmentData.builder()
+                                            .type(rs.getType())
+                                            .schedule(BulkCreateRecruitmentsCommand.ScheduleData.builder()
+                                                    .applicationStartTime(rs.getSchedule().getApplicationStartTime())
+                                                    .applicationEndTime(rs.getSchedule().getApplicationEndTime())
+                                                    .applicationResultTime(rs.getSchedule().getApplicationResultTime())
+                                                    .interviewStartTime(rs.getSchedule().getInterviewStartTime())
+                                                    .interviewEndTime(rs.getSchedule().getInterviewEndTime())
+                                                    .finalResultTime(rs.getSchedule().getFinalResultTime())
+                                                    .build())
+                                            .build())
+                                    .toList())
+                            .build()
+            );
+        }
+
+        cacheService.evict(CacheType.ADMIN_MAIN_DATA, "common_" + generationId);
+        log.info("공통 탭 배포 완료 - generation={}", generationId);
+
+        return AddAdminConfirmResponseDto.builder()
+                .message("공통 탭 배포 성공")
+                .build();
+    }
+
+    // =========================================================
+    // 탭별 배포 - 홈 탭
+    // =========================================================
+
+    @Override
+    @Transactional
+    public AddAdminHomeResponseDto addHomeData(AddAdminHomeRequestDto request) {
+        log.info("홈 탭 배포 1단계 - generation={}", request.getGeneration());
+
+        Integer generationId = request.getGeneration();
+        String baseDir = generationId + "/";
+
+        CachedHomeData cachedData = new CachedHomeData();
+        cachedData.setGenerationId(generationId);
+
+        String homeHeaderImageUrl = s3Service.generatePresignedUrl(
+                request.getHomeHeaderImageFileName(), baseDir);
+        cachedData.setHomeHeaderImageUrl(homeHeaderImageUrl);
+
+        List<CachedAdminData.NewsData> newsDataList = new ArrayList<>();
+        if (request.getNews() != null) {
+            for (var news : request.getNews()) {
+                String newsImageUrl = s3Service.generatePresignedUrl(
+                        news.getImageFileName(), baseDir + "news/");
+                newsDataList.add(CachedAdminData.NewsData.builder()
+                        .title(news.getTitle())
+                        .link(news.getLink())
+                        .imageUrl(newsImageUrl)
+                        .build());
+            }
+        }
+        cachedData.setNews(newsDataList);
+
+        if (request.getReview() != null) {
+            cachedData.setReviews(new ArrayList<>(request.getReview()));
+        }
+
+        cacheService.put(CacheType.ADMIN_MAIN_DATA, "home_" + generationId, cachedData);
+        log.info("홈 탭 캐시 저장 완료 - generation={}", generationId);
+
+        return AddAdminHomeResponseDto.builder()
+                .generation(generationId)
+                .homeHeaderImage(homeHeaderImageUrl)
+                .news(newsDataList.stream()
+                        .map(n -> AddAdminNewsResponseRecordDto.builder()
+                                .title(n.getTitle())
+                                .imagePresignedUrl(n.getImageUrl())
+                                .build())
+                        .toList())
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public AddAdminConfirmResponseDto addHomeDataConfirm(AddAdminConfirmRequestDto request) {
+        log.info("홈 탭 배포 2단계 - generation={}", request.getGeneration());
+
+        Integer generationId = request.getGeneration();
+
+        CachedHomeData cachedData = cacheService.get(
+                CacheType.ADMIN_MAIN_DATA, "home_" + generationId, CachedHomeData.class);
+
+        if (cachedData == null) {
+            throw new ClientBadRequestException(
+                    "홈 탭 캐시 데이터 없음. 배포 1단계를 먼저 호출하세요. generation=" + generationId);
+        }
+
+        String homeHeaderImageUrl = s3Service.getOriginalUrl(cachedData.getHomeHeaderImageUrl());
+        generationService.updateHomeHeaderImage(generationId, homeHeaderImageUrl);
+
+        if (cachedData.getNews() != null && !cachedData.getNews().isEmpty()) {
+            newsService.bulkCreate(
+                    BulkCreateNewsCommand.builder()
+                            .news(cachedData.getNews().stream()
+                                    .map(n -> BulkCreateNewsCommand.NewsData.builder()
+                                            .title(n.getTitle())
+                                            .link(n.getLink())
+                                            .imageUrl(s3Service.getOriginalUrl(n.getImageUrl()))
+                                            .build())
+                                    .toList())
+                            .build()
+            );
+        }
+
+        if (cachedData.getReviews() != null && !cachedData.getReviews().isEmpty()) {
+            homepageReviewService.bulkCreate(
+                    BulkCreateHomepageReviewsCommand.builder()
+                            .reviews(cachedData.getReviews().stream()
+                                    .map(r -> BulkCreateHomepageReviewsCommand.ReviewData.builder()
+                                            .title(r.getTitle())
+                                            .content(r.getContent())
+                                            .authorInfo(r.getAuthorInfo())
+                                            .build())
+                                    .toList())
+                            .build()
+            );
+        }
+
+        cacheService.evict(CacheType.ADMIN_MAIN_DATA, "home_" + generationId);
+        log.info("홈 탭 배포 완료 - generation={}", generationId);
+
+        return AddAdminConfirmResponseDto.builder()
+                .message("홈 탭 배포 성공")
+                .build();
+    }
+
+    // =========================================================
+    // 탭별 배포 - 소개 탭
+    // =========================================================
+
+    @Override
+    @Transactional
+    public AddAdminAboutResponseDto addAboutData(AddAdminAboutRequestDto request) {
+        log.info("소개 탭 배포 1단계 - generation={}", request.getGeneration());
+
+        Integer generationId = request.getGeneration();
+        String baseDir = generationId + "/";
+
+        CachedAboutData cachedData = new CachedAboutData();
+        cachedData.setGenerationId(generationId);
+
+        String headerImageUrl = s3Service.generatePresignedUrl(
+                request.getHeaderImageFileName(), baseDir);
+        cachedData.setHeaderImageUrl(headerImageUrl);
+
+        List<CachedAdminData.CoreValueData> coreValueDataList = new ArrayList<>();
+        if (request.getCoreValue() != null) {
+            for (var cv : request.getCoreValue()) {
+                String imageUrl = s3Service.generatePresignedUrl(
+                        cv.getImageFileName(), baseDir + "coreValue/");
+                coreValueDataList.add(CachedAdminData.CoreValueData.builder()
+                        .value(cv.getValue())
+                        .description(cv.getDescription())
+                        .detailDescription(cv.getDetailDescription())
+                        .imageUrl(imageUrl)
+                        .build());
+            }
+        }
+        cachedData.setCoreValues(coreValueDataList);
+
+        List<CachedAdminData.MemberData> memberDataList = new ArrayList<>();
+        if (request.getMember() != null) {
+            for (var member : request.getMember()) {
+                String profileImageUrl = s3Service.generatePresignedUrl(
+                        member.getProfileImageFileName(), baseDir + "member/");
+                memberDataList.add(CachedAdminData.MemberData.builder()
+                        .role(member.getRole())
+                        .name(member.getName())
+                        .affiliation(member.getAffiliation())
+                        .introduction(member.getIntroduction())
+                        .profileImageUrl(profileImageUrl)
+                        .snsEmail(member.getSns() != null ? member.getSns().getEmail() : null)
+                        .snsLinkedin(member.getSns() != null ? member.getSns().getLinkedin() : null)
+                        .snsGithub(member.getSns() != null ? member.getSns().getGithub() : null)
+                        .snsBehance(member.getSns() != null ? member.getSns().getBehance() : null)
+                        .build());
+            }
+        }
+        cachedData.setMembers(memberDataList);
+
+        if (request.getActivitySchedule() != null) {
+            cachedData.setActivitySchedules(new ArrayList<>(request.getActivitySchedule()));
+        }
+
+        cacheService.put(CacheType.ADMIN_MAIN_DATA, "about_" + generationId, cachedData);
+        log.info("소개 탭 캐시 저장 완료 - generation={}", generationId);
+
+        return AddAdminAboutResponseDto.builder()
+                .generation(generationId)
+                .headerImage(headerImageUrl)
+                .coreValues(coreValueDataList.stream()
+                        .map(cv -> AddAdminCoreValueResponseRecordDto.builder()
+                                .value(cv.getValue())
+                                .image(cv.getImageUrl())
+                                .build())
+                        .toList())
+                .members(memberDataList.stream()
+                        .map(m -> AddAdminMemberResponseRecordDto.builder()
+                                .role(m.getRole())
+                                .name(m.getName())
+                                .profileImage(m.getProfileImageUrl())
+                                .build())
+                        .toList())
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public AddAdminConfirmResponseDto addAboutDataConfirm(AddAdminConfirmRequestDto request) {
+        log.info("소개 탭 배포 2단계 - generation={}", request.getGeneration());
+
+        Integer generationId = request.getGeneration();
+
+        CachedAboutData cachedData = cacheService.get(
+                CacheType.ADMIN_MAIN_DATA, "about_" + generationId, CachedAboutData.class);
+
+        if (cachedData == null) {
+            throw new ClientBadRequestException(
+                    "소개 탭 캐시 데이터 없음. 배포 1단계를 먼저 호출하세요. generation=" + generationId);
+        }
+
+        String headerImageUrl = s3Service.getOriginalUrl(cachedData.getHeaderImageUrl());
+        generationService.updateHeaderImage(generationId, headerImageUrl);
+
+        if (cachedData.getCoreValues() != null && !cachedData.getCoreValues().isEmpty()) {
+            List<String> coreValueImageUrls = cachedData.getCoreValues().stream()
+                    .map(cv -> s3Service.getOriginalUrl(cv.getImageUrl()))
+                    .toList();
+
+            List<BulkCreateCoreValuesCommand.CoreValueData> coreValueDataList = new ArrayList<>();
+            for (int i = 0; i < cachedData.getCoreValues().size(); i++) {
+                var cv = cachedData.getCoreValues().get(i);
+                coreValueDataList.add(BulkCreateCoreValuesCommand.CoreValueData.builder()
+                        .value(cv.getValue())
+                        .description(cv.getDescription())
+                        .detailDescription(cv.getDetailDescription())
+                        .imageUrl(coreValueImageUrls.get(i))
+                        .displayOrder(i)
+                        .build());
+            }
+            coreValueService.bulkCreate(
+                    BulkCreateCoreValuesCommand.builder()
+                            .generationId(generationId)
+                            .coreValues(coreValueDataList)
+                            .build()
+            );
+        }
+
+        if (cachedData.getMembers() != null && !cachedData.getMembers().isEmpty()) {
+            List<String> memberProfileImageUrls = cachedData.getMembers().stream()
+                    .map(m -> s3Service.getOriginalUrl(m.getProfileImageUrl()))
+                    .toList();
+
+            List<BulkCreateMembersCommand.MemberData> memberDataList = new ArrayList<>();
+            for (int i = 0; i < cachedData.getMembers().size(); i++) {
+                var m = cachedData.getMembers().get(i);
+                memberDataList.add(BulkCreateMembersCommand.MemberData.builder()
+                        .role(m.getRole())
+                        .name(m.getName())
+                        .affiliation(m.getAffiliation())
+                        .introduction(m.getIntroduction())
+                        .profileImageUrl(memberProfileImageUrls.get(i))
+                        .snsLinks(BulkCreateMembersCommand.SnsLinksData.builder()
+                                .email(m.getSnsEmail())
+                                .linkedin(m.getSnsLinkedin())
+                                .github(m.getSnsGithub())
+                                .behance(m.getSnsBehance())
+                                .build())
+                        .build());
+            }
+            memberService.bulkCreate(
+                    BulkCreateMembersCommand.builder()
+                            .generationId(generationId)
+                            .members(memberDataList)
+                            .build()
+            );
+        }
+
+        if (cachedData.getActivitySchedules() != null && !cachedData.getActivitySchedules().isEmpty()) {
+            activityScheduleService.bulkCreate(
+                    BulkCreateActivitySchedulesCommand.builder()
+                            .generationId(generationId)
+                            .activitySchedules(cachedData.getActivitySchedules().stream()
+                                    .map(s -> BulkCreateActivitySchedulesCommand.ActivityScheduleData.builder()
+                                            .name(s.getName())
+                                            .startDate(java.time.LocalDate.parse(s.getStartDate()))
+                                            .endDate(s.getEndDate() != null ? java.time.LocalDate.parse(s.getEndDate()) : null)
+                                            .build())
+                                    .toList())
+                            .build()
+            );
+        }
+
+        cacheService.evict(CacheType.ADMIN_MAIN_DATA, "about_" + generationId);
+        log.info("소개 탭 배포 완료 - generation={}", generationId);
+
+        return AddAdminConfirmResponseDto.builder()
+                .message("소개 탭 배포 성공")
+                .build();
+    }
+
+    // =========================================================
+    // 탭별 배포 - 모집안내 탭
+    // =========================================================
+
+    @Override
+    @Transactional
+    public AddAdminRecruitResponseDto addRecruitData(AddAdminRecruitRequestDto request) {
+        log.info("모집안내 탭 배포 1단계 - generation={}", request.getGeneration());
+
+        Integer generationId = request.getGeneration();
+        String baseDir = generationId + "/";
+
+        CachedRecruitData cachedData = new CachedRecruitData();
+        cachedData.setGenerationId(generationId);
+
+        String recruitHeaderImageUrl = s3Service.generatePresignedUrl(
+                request.getRecruitHeaderImageFileName(), baseDir);
+        cachedData.setRecruitHeaderImageUrl(recruitHeaderImageUrl);
+
+        if (request.getPartIntroduction() != null) {
+            cachedData.setPartIntroductions(new ArrayList<>(request.getPartIntroduction()));
+        }
+        if (request.getPartCurriculum() != null) {
+            cachedData.setPartCurriculums(new ArrayList<>(request.getPartCurriculum()));
+        }
+        if (request.getRecruitPartCurriculum() != null) {
+            cachedData.setRecruitPartCurriculums(new ArrayList<>(request.getRecruitPartCurriculum()));
+        }
+        if (request.getRecruitQuestion() != null) {
+            cachedData.setRecruitQuestions(new ArrayList<>(request.getRecruitQuestion()));
+        }
+
+        cacheService.put(CacheType.ADMIN_MAIN_DATA, "recruit_" + generationId, cachedData);
+        log.info("모집안내 탭 캐시 저장 완료 - generation={}", generationId);
+
+        return AddAdminRecruitResponseDto.builder()
+                .generation(generationId)
+                .recruitHeaderImage(recruitHeaderImageUrl)
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public AddAdminConfirmResponseDto addRecruitDataConfirm(AddAdminConfirmRequestDto request) {
+        log.info("모집안내 탭 배포 2단계 - generation={}", request.getGeneration());
+
+        Integer generationId = request.getGeneration();
+
+        CachedRecruitData cachedData = cacheService.get(
+                CacheType.ADMIN_MAIN_DATA, "recruit_" + generationId, CachedRecruitData.class);
+
+        if (cachedData == null) {
+            throw new ClientBadRequestException(
+                    "모집안내 탭 캐시 데이터 없음. 배포 1단계를 먼저 호출하세요. generation=" + generationId);
+        }
+
+        String recruitHeaderImageUrl = s3Service.getOriginalUrl(cachedData.getRecruitHeaderImageUrl());
+        generationService.updateRecruitHeaderImage(generationId, recruitHeaderImageUrl);
+
+        if (cachedData.getPartIntroductions() != null || cachedData.getPartCurriculums() != null) {
+            partService.bulkCreate(
+                    BulkCreatePartsCommand.builder()
+                            .generationId(generationId)
+                            .partIntroductions(cachedData.getPartIntroductions() != null
+                                    ? cachedData.getPartIntroductions().stream()
+                                            .map(pi -> BulkCreatePartsCommand.PartData.builder()
+                                                    .part(pi.getPart())
+                                                    .description(pi.getDescription())
+                                                    .build())
+                                            .toList()
+                                    : List.of())
+                            .partCurriculums(cachedData.getPartCurriculums() != null
+                                    ? cachedData.getPartCurriculums().stream()
+                                            .map(pc -> BulkCreatePartsCommand.PartCurriculumData.builder()
+                                                    .part(pc.getPart())
+                                                    .curriculums(pc.getCurriculums())
+                                                    .build())
+                                            .toList()
+                                    : List.of())
+                            .build()
+            );
+        }
+
+        if (cachedData.getRecruitPartCurriculums() != null && !cachedData.getRecruitPartCurriculums().isEmpty()) {
+            recruitPartIntroductionService.bulkCreate(
+                    BulkCreateRecruitPartIntroductionsCommand.builder()
+                            .generationId(generationId)
+                            .partIntroductions(cachedData.getRecruitPartCurriculums().stream()
+                                    .map(rpc -> BulkCreateRecruitPartIntroductionsCommand.PartIntroductionData.builder()
+                                            .part(rpc.getPart())
+                                            .introduction(
+                                                    BulkCreateRecruitPartIntroductionsCommand.IntroductionData.builder()
+                                                            .content(rpc.getIntroduction().getContent())
+                                                            .preference(rpc.getIntroduction().getPreference())
+                                                            .build())
+                                            .build())
+                                    .toList())
+                            .build()
+            );
+        }
+
+        if (cachedData.getRecruitQuestions() != null && !cachedData.getRecruitQuestions().isEmpty()) {
+            faqService.bulkCreate(
+                    BulkCreateFAQsCommand.builder()
+                            .faqs(cachedData.getRecruitQuestions().stream()
+                                    .map(rq -> BulkCreateFAQsCommand.FAQData.builder()
+                                            .part(rq.getPart())
+                                            .question(rq.getQuestions().stream()
+                                                    .map(q -> BulkCreateFAQsCommand.QuestionData.builder()
+                                                            .question(q.getQuestion())
+                                                            .answer(q.getAnswer())
+                                                            .build())
+                                                    .toList())
+                                            .build())
+                                    .toList())
+                            .build()
+            );
+        }
+
+        cacheService.evict(CacheType.ADMIN_MAIN_DATA, "recruit_" + generationId);
+        log.info("모집안내 탭 배포 완료 - generation={}", generationId);
+
+        return AddAdminConfirmResponseDto.builder()
+                .message("모집안내 탭 배포 성공")
+                .build();
+    }
+
+    // =========================================================
+    // 유틸리티
+    // =========================================================
+
+    /** BrandingColor VO는 '#' 없는 6자리 hex 요구 → '#' 제거 */
+    private String stripHash(String hexColor) {
+        if (hexColor != null && hexColor.startsWith("#")) {
+            return hexColor.substring(1);
+        }
+        return hexColor;
+    }
+
     /**
      * Admin 메인 데이터 조회
      */
@@ -665,6 +1194,49 @@ public class AdminServiceImpl implements AdminService {
             private String link;
             private String imageUrl;
         }
+    }
+
+    // ===== 탭별 캐시 데이터 클래스 =====
+
+    @lombok.Data
+    public static class CachedCommonData implements java.io.Serializable {
+        private Integer generationId;
+        private String name;
+        private String brandingColorMain;
+        private String brandingColorLow;
+        private String brandingColorHigh;
+        private String brandingColorPoint;
+        private String mainButtonText;
+        private String mainButtonKeyColor;
+        private String mainButtonSubColor;
+        private List<AddAdminRecruitScheduleRequestDto> recruitSchedules;
+    }
+
+    @lombok.Data
+    public static class CachedHomeData implements java.io.Serializable {
+        private Integer generationId;
+        private String homeHeaderImageUrl;
+        private List<CachedAdminData.NewsData> news;
+        private List<AddAdminReviewRequestDto> reviews;
+    }
+
+    @lombok.Data
+    public static class CachedAboutData implements java.io.Serializable {
+        private Integer generationId;
+        private String headerImageUrl;
+        private List<CachedAdminData.CoreValueData> coreValues;
+        private List<CachedAdminData.MemberData> members;
+        private List<AddAdminActivityScheduleRequestDto> activitySchedules;
+    }
+
+    @lombok.Data
+    public static class CachedRecruitData implements java.io.Serializable {
+        private Integer generationId;
+        private String recruitHeaderImageUrl;
+        private List<AddAdminPartIntroductionRequestDto> partIntroductions;
+        private List<AddAdminPartCurriculumRequestDto> partCurriculums;
+        private List<AddAdminRecruitPartCurriculumRequestDto> recruitPartCurriculums;
+        private List<AddAdminRecruitQuestionRequestDto> recruitQuestions;
     }
 
 }

--- a/src/main/java/sopt/org/homepage/generation/GenerationService.java
+++ b/src/main/java/sopt/org/homepage/generation/GenerationService.java
@@ -1,11 +1,14 @@
 package sopt.org.homepage.generation;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sopt.org.homepage.generation.dto.CreateGenerationCommand;
 import sopt.org.homepage.generation.dto.GenerationDetailView;
+import sopt.org.homepage.generation.vo.BrandingColor;
+import sopt.org.homepage.generation.vo.MainButton;
 import sopt.org.homepage.global.exception.ClientBadRequestException;
 
 /**
@@ -41,6 +44,71 @@ public class GenerationService {
 
         log.info("기수 생성 완료 - id={}", saved.getId());
         return saved.getId();
+    }
+
+    /**
+     * 공통 탭 배포: Generation 없으면 생성(이미지 공란), 있으면 공통 필드만 업데이트
+     */
+    @Transactional
+    public void createOrUpdateCommon(Integer id, String name, BrandingColor brandingColor, MainButton mainButton) {
+        log.info("공통 탭 Generation createOrUpdate - id={}", id);
+
+        Optional<Generation> opt = generationRepository.findById(id);
+        if (opt.isEmpty()) {
+            Generation gen = Generation.builder()
+                    .id(id)
+                    .name(name)
+                    .headerImage("")
+                    .recruitHeaderImage("")
+                    .homeHeaderImage("")
+                    .brandingColor(brandingColor)
+                    .mainButton(mainButton)
+                    .build();
+            generationRepository.save(gen);
+        } else {
+            Generation gen = opt.get();
+            gen.update(name, gen.getHeaderImage(), gen.getRecruitHeaderImage(),
+                    gen.getHomeHeaderImage(), brandingColor, mainButton);
+        }
+    }
+
+    /**
+     * 홈 탭 배포: homeHeaderImage 업데이트
+     */
+    @Transactional
+    public void updateHomeHeaderImage(Integer id, String homeHeaderImage) {
+        log.info("홈 탭 Generation homeHeaderImage 업데이트 - id={}", id);
+
+        Generation gen = generationRepository.findById(id)
+                .orElseThrow(() -> new ClientBadRequestException(
+                        "공통 탭을 먼저 배포해야 합니다. Generation not found: " + id));
+        gen.updateHomeHeaderImage(homeHeaderImage);
+    }
+
+    /**
+     * 소개 탭 배포: headerImage 업데이트
+     */
+    @Transactional
+    public void updateHeaderImage(Integer id, String headerImage) {
+        log.info("소개 탭 Generation headerImage 업데이트 - id={}", id);
+
+        Generation gen = generationRepository.findById(id)
+                .orElseThrow(() -> new ClientBadRequestException(
+                        "공통 탭을 먼저 배포해야 합니다. Generation not found: " + id));
+        gen.updateHeaderImage(headerImage);
+    }
+
+    /**
+     * 모집안내 탭 배포: recruitHeaderImage 업데이트
+     */
+    @Transactional
+    public void updateRecruitHeaderImage(Integer id, String recruitHeaderImage) {
+        log.info("모집안내 탭 Generation recruitHeaderImage 업데이트 - id={}", id);
+
+        Generation gen = generationRepository.findById(id)
+                .orElseThrow(() -> new ClientBadRequestException(
+                        "공통 탭을 먼저 배포해야 합니다. Generation not found: " + id));
+        gen.updateRecruitHeaderImage(recruitHeaderImage);
     }
 
     // ===== Query 메서드 =====

--- a/src/main/java/sopt/org/homepage/global/common/type/PartType.java
+++ b/src/main/java/sopt/org/homepage/global/common/type/PartType.java
@@ -64,6 +64,7 @@ public enum PartType {
             case "서버", "Server", "SERVER" -> SERVER;
             case "기획", "Plan", "PLAN" -> PLAN;
             case "디자인", "Design", "DESIGN" -> DESIGN;
+            case "공통", "Common", "COMMON" -> COMMON;
             default -> throw new IllegalArgumentException("Unknown partType: " + partName);
         };
     }


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 이 PR이 해결하는 이슈 -->
Related to #254 

## 📋 작업 내용 요약

<!-- 이 PR에서 무엇을 했나요? -->

### 주요 변경사항
- 기존 어드민 배포 엔드포인트를 탭별로 분리

## 💡 구현 방법

<!-- 어떻게 구현했나요? 기술적 선택의 이유는? -->

## 📸 스크린샷 / 실행 결과

<!-- UI 변경이나 실행 결과가 있다면 -->

## 🧪 테스트

<!-- 어떤 테스트를 했나요? -->

### 테스트 케이스

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 추가/수정
- [ ] 수동 테스트 완료

### 테스트 시나리오

1.
2.
3.

## 🔍 리뷰 포인트

<!-- 리뷰어가 특히 봐줬으면 하는 부분 -->
- 

-

## ⚠️ 주의사항

<!-- 배포 시 주의할 점이나 Breaking Changes -->

- [ ] Breaking Change 없음
- [ ] DB 마이그레이션 필요 (있다면 설명)
- [ ] 환경 변수 추가/변경 (있다면 설명)
- [ ] 의존성 추가/변경 (있다면 설명)

## 📝 추가 메모

<!-- 기타 참고사항 -->



---

## ✅ PR 체크리스트

- [ ] 코드 스타일 가이드 준수
- [ ] Self Review 완료
- [ ] 테스트 코드 작성 및 통과
- [ ] 문서 업데이트 (필요 시)
- [ ] 커밋 메시지 컨벤션 준수
- [ ] 충돌(Conflict) 해결 완료
