### PR TITLE
[FEAT] 최신 소식 수정 기능 구현

### DIFF
--- a/src/main/java/sopt/org/homepage/application/homepage/service/HomepageQueryService.java
+++ b/src/main/java/sopt/org/homepage/application/homepage/service/HomepageQueryService.java
@@ -1,5 +1,6 @@
 package sopt.org.homepage.application.homepage.service;
 
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -299,7 +300,8 @@ public class HomepageQueryService {
             // Study 개수 조회 (Crew API)
             int studyCount = crewService.getStudyCount(generationId);
 
-            final int OPERATION_PERIOD = 37;
+            final int ORGANIZATION_YEAR = 2008;
+            int OPERATION_PERIOD = LocalDate.now().getYear() - ORGANIZATION_YEAR + 1;
 
             return MainPageResponse.ActivitiesRecords.builder()
                     .activitiesMemberCount((int) activitiesMemberCount)

--- a/src/main/java/sopt/org/homepage/news/News.java
+++ b/src/main/java/sopt/org/homepage/news/News.java
@@ -54,4 +54,10 @@ public class News {
         this.link = link;
     }
 
+    public void update(String image, String title, String link) {
+        if (image != null) this.image = image;
+        this.title = title;
+        this.link = link;
+    }
+
 }

--- a/src/main/java/sopt/org/homepage/news/NewsController.java
+++ b/src/main/java/sopt/org/homepage/news/NewsController.java
@@ -11,6 +11,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,6 +23,9 @@ import sopt.org.homepage.news.dto.AddAdminNewsResponseDto;
 import sopt.org.homepage.news.dto.AddAdminNewsV2RequestDto;
 import sopt.org.homepage.news.dto.DeleteAdminNewsRequestDto;
 import sopt.org.homepage.news.dto.DeleteAdminNewsResponseDto;
+import sopt.org.homepage.news.dto.EditAdminNewsRequestDto;
+import sopt.org.homepage.news.dto.EditAdminNewsResponseDto;
+import sopt.org.homepage.news.dto.EditAdminNewsV2RequestDto;
 import sopt.org.homepage.news.dto.GetAdminNewsRequestDto;
 import sopt.org.homepage.news.dto.GetAdminNewsResponseDto;
 
@@ -59,6 +64,29 @@ public class NewsController {
     ) {
         AddAdminNewsResponseDto result = newsService.addMainNewsV2(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(result);
+    }
+
+    @Operation(summary = "최신소식 수정", description = "최신소식을 수정합니다")
+    @PatchMapping(value = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<EditAdminNewsResponseDto> editMainNews(
+            @PathVariable int id,
+            @ModelAttribute EditAdminNewsRequestDto request
+    ) {
+        EditAdminNewsResponseDto result = newsService.editMainNews(id, request);
+        return ResponseEntity.status(HttpStatus.OK).body(result);
+    }
+
+    @Operation(
+            summary = "최신소식 수정 (Presigned URL)",
+            description = "람다 전용"
+    )
+    @PatchMapping("/{id}/v2")
+    public ResponseEntity<EditAdminNewsResponseDto> editMainNewsV2(
+            @PathVariable int id,
+            @RequestBody @Valid EditAdminNewsV2RequestDto request
+    ) {
+        EditAdminNewsResponseDto result = newsService.editMainNewsV2(id, request);
+        return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 
     @Operation(summary = "최신소식 삭제", description = "최신소식을 삭제합니다")

--- a/src/main/java/sopt/org/homepage/news/NewsService.java
+++ b/src/main/java/sopt/org/homepage/news/NewsService.java
@@ -8,11 +8,14 @@ import org.springframework.transaction.annotation.Transactional;
 import sopt.org.homepage.global.exception.ClientBadRequestException;
 import sopt.org.homepage.infrastructure.aws.s3.S3Service;
 import sopt.org.homepage.news.dto.AddAdminNewsRequestDto;
-import sopt.org.homepage.news.dto.BulkCreateNewsCommand;
 import sopt.org.homepage.news.dto.AddAdminNewsResponseDto;
 import sopt.org.homepage.news.dto.AddAdminNewsV2RequestDto;
+import sopt.org.homepage.news.dto.BulkCreateNewsCommand;
 import sopt.org.homepage.news.dto.DeleteAdminNewsRequestDto;
 import sopt.org.homepage.news.dto.DeleteAdminNewsResponseDto;
+import sopt.org.homepage.news.dto.EditAdminNewsRequestDto;
+import sopt.org.homepage.news.dto.EditAdminNewsResponseDto;
+import sopt.org.homepage.news.dto.EditAdminNewsV2RequestDto;
 import sopt.org.homepage.news.dto.GetAdminNewsRequestDto;
 import sopt.org.homepage.news.dto.GetAdminNewsResponseDto;
 
@@ -79,6 +82,60 @@ public class NewsService {
 
         return AddAdminNewsResponseDto.builder()
                 .message("최신소식 추가 성공")
+                .build();
+    }
+
+    /**
+     * 최신소식 수정 (파일 업로드 방식)
+     */
+    @Transactional
+    public EditAdminNewsResponseDto editMainNews(int id, EditAdminNewsRequestDto request) {
+        log.info("최신소식 수정 - id={}", id);
+
+        News news = newsRepository.findById(id)
+                .orElseThrow(() -> new ClientBadRequestException(
+                        "News not found with id: " + id
+                ));
+
+        String imageUrl = null;
+        if (request.getImage() != null && !request.getImage().isEmpty()) {
+            s3Service.deleteFile(news.getImage());
+            imageUrl = s3Service.uploadFile(request.getImage(), "news/");
+        }
+
+        news.update(imageUrl, request.getTitle(), request.getLink());
+
+        log.info("최신소식 수정 완료 - id={}", id);
+
+        return EditAdminNewsResponseDto.builder()
+                .message("최신소식 수정 성공")
+                .build();
+    }
+
+    /**
+     * 최신소식 수정 (Presigned URL 방식)
+     * <p>
+     * Lambda 환경에서 10MB 페이로드 제한을 우회하기 위해 사용
+     */
+    @Transactional
+    public EditAdminNewsResponseDto editMainNewsV2(int id, EditAdminNewsV2RequestDto request) {
+        log.info("최신소식 수정 (Presigned URL) - id={}", id);
+
+        News news = newsRepository.findById(id)
+                .orElseThrow(() -> new ClientBadRequestException(
+                        "News not found with id: " + id
+                ));
+
+        if (!request.getImageUrl().equals(news.getImage())) {
+            s3Service.deleteFile(news.getImage());
+        }
+
+        news.update(request.getImageUrl(), request.getTitle(), request.getLink());
+
+        log.info("최신소식 수정 완료 (Presigned URL) - id={}", id);
+
+        return EditAdminNewsResponseDto.builder()
+                .message("최신소식 수정 성공")
                 .build();
     }
 

--- a/src/main/java/sopt/org/homepage/news/dto/EditAdminNewsRequestDto.java
+++ b/src/main/java/sopt/org/homepage/news/dto/EditAdminNewsRequestDto.java
@@ -1,0 +1,26 @@
+package sopt.org.homepage.news.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.multipart.MultipartFile;
+
+@Validated
+@Schema(description = "최신소식 수정하기")
+@Getter
+@RequiredArgsConstructor
+public class EditAdminNewsRequestDto {
+
+    @Schema(description = "이미지 (변경 시에만 업로드)", type = "string", format = "binary")
+    private final MultipartFile image;
+
+    @Schema(description = "제목", requiredMode = Schema.RequiredMode.REQUIRED, example = "MIND 24")
+    @NotBlank(message = "title must not be blank")
+    private final String title;
+
+    @Schema(description = "링크", requiredMode = Schema.RequiredMode.REQUIRED, example = "https://example.com")
+    @NotBlank(message = "link must not be blank")
+    private final String link;
+}

--- a/src/main/java/sopt/org/homepage/news/dto/EditAdminNewsResponseDto.java
+++ b/src/main/java/sopt/org/homepage/news/dto/EditAdminNewsResponseDto.java
@@ -1,0 +1,18 @@
+package sopt.org.homepage.news.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@Schema(description = "최신소식 수정")
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class EditAdminNewsResponseDto {
+
+    @Schema(description = "성공 메세지", requiredMode = Schema.RequiredMode.REQUIRED, example = "success")
+    private final String message;
+}

--- a/src/main/java/sopt/org/homepage/news/dto/EditAdminNewsV2RequestDto.java
+++ b/src/main/java/sopt/org/homepage/news/dto/EditAdminNewsV2RequestDto.java
@@ -1,0 +1,34 @@
+package sopt.org.homepage.news.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@Schema(description = "최신소식 수정하기 (Presigned URL 방식)")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EditAdminNewsV2RequestDto {
+
+    @Schema(
+            description = "S3에 업로드된 이미지 URL",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            example = "https://s3.ap-northeast-2.amazonaws.com/sopt.org/develop/news/uuid_image.jpg"
+    )
+    @NotBlank(message = "imageUrl must not be blank")
+    private String imageUrl;
+
+    @Schema(description = "제목", requiredMode = Schema.RequiredMode.REQUIRED, example = "SOPT 36기 모집 안내")
+    @NotBlank(message = "title must not be blank")
+    private String title;
+
+    @Schema(description = "링크", requiredMode = Schema.RequiredMode.REQUIRED, example = "https://sopt.org/recruit")
+    @NotBlank(message = "link must not be blank")
+    private String link;
+}

--- a/src/test/java/sopt/org/homepage/news/NewsServiceTest.java
+++ b/src/test/java/sopt/org/homepage/news/NewsServiceTest.java
@@ -17,6 +17,7 @@ import sopt.org.homepage.global.exception.ClientBadRequestException;
 import sopt.org.homepage.infrastructure.aws.s3.S3Service;
 import sopt.org.homepage.news.dto.AddAdminNewsV2RequestDto;
 import sopt.org.homepage.news.dto.DeleteAdminNewsRequestDto;
+import sopt.org.homepage.news.dto.EditAdminNewsV2RequestDto;
 import sopt.org.homepage.news.dto.GetAdminNewsRequestDto;
 import sopt.org.homepage.news.dto.GetAdminNewsResponseDto;
 
@@ -66,6 +67,68 @@ class NewsServiceTest extends IntegrationTestBase {
             assertThat(all).hasSize(1);
             assertThat(all.get(0).getTitle()).isEqualTo("SOPT 35기 모집");
             assertThat(all.get(0).getImage()).isEqualTo("https://s3.amazonaws.com/bucket/image.jpg");
+        }
+    }
+
+    // ===== 수정 시나리오 =====
+
+    @Nested
+    @DisplayName("최신소식 수정")
+    class Edit {
+
+        @Test
+        @DisplayName("✅ 정상: 제목과 링크 수정 (이미지 동일)")
+        void editMainNewsV2_UpdateTitleAndLink_Success() {
+            // given
+            News saved = newsRepository.save(createEntity("원본 뉴스"));
+            EditAdminNewsV2RequestDto request = EditAdminNewsV2RequestDto.builder()
+                    .imageUrl(saved.getImage())
+                    .title("수정된 뉴스")
+                    .link("https://updated.com")
+                    .build();
+
+            // when
+            newsService.editMainNewsV2(saved.getId(), request);
+
+            // then
+            News updated = newsRepository.findById(saved.getId()).orElseThrow();
+            assertThat(updated.getTitle()).isEqualTo("수정된 뉴스");
+            assertThat(updated.getLink()).isEqualTo("https://updated.com");
+            assertThat(updated.getImage()).isEqualTo(saved.getImage());
+        }
+
+        @Test
+        @DisplayName("✅ 정상: 이미지 URL 수정 시 기존 S3 이미지 삭제")
+        void editMainNewsV2_UpdateImage_DeletesOldImage() {
+            // given
+            News saved = newsRepository.save(createEntity("뉴스"));
+            doNothing().when(s3Service).deleteFile(anyString());
+            EditAdminNewsV2RequestDto request = EditAdminNewsV2RequestDto.builder()
+                    .imageUrl("https://s3.amazonaws.com/bucket/new_image.jpg")
+                    .title(saved.getTitle())
+                    .link(saved.getLink())
+                    .build();
+
+            // when
+            newsService.editMainNewsV2(saved.getId(), request);
+
+            // then
+            News updated = newsRepository.findById(saved.getId()).orElseThrow();
+            assertThat(updated.getImage()).isEqualTo("https://s3.amazonaws.com/bucket/new_image.jpg");
+        }
+
+        @Test
+        @DisplayName("❌ 실패: 존재하지 않는 뉴스 수정")
+        void editMainNewsV2_NotFound_ThrowsException() {
+            // given
+            EditAdminNewsV2RequestDto request = EditAdminNewsV2RequestDto.builder()
+                    .title("수정 시도")
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> newsService.editMainNewsV2(999, request))
+                    .isInstanceOf(ClientBadRequestException.class)
+                    .hasMessageContaining("not found");
         }
     }
 


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 이 PR이 해결하는 이슈 -->
Related to #259 

## 📋 작업 내용 요약

<!-- 이 PR에서 무엇을 했나요? -->

### 주요 변경사항
- 최신 소식 수정 기능을 구현했습니다.

- 동아리 운영 기간도 현재 날짜에 따라 자동으로 계산되도록 변경했습니다.

## 💡 구현 방법

<!-- 어떻게 구현했나요? 기술적 선택의 이유는? -->

## 📸 스크린샷 / 실행 결과

<!-- UI 변경이나 실행 결과가 있다면 -->

## 🧪 테스트

<!-- 어떤 테스트를 했나요? -->

### 테스트 케이스

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 추가/수정
- [ ] 수동 테스트 완료

### 테스트 시나리오

1.
2.
3.

## 🔍 리뷰 포인트

<!-- 리뷰어가 특히 봐줬으면 하는 부분 -->
- 

-

## ⚠️ 주의사항

<!-- 배포 시 주의할 점이나 Breaking Changes -->

- [ ] Breaking Change 없음
- [ ] DB 마이그레이션 필요 (있다면 설명)
- [ ] 환경 변수 추가/변경 (있다면 설명)
- [ ] 의존성 추가/변경 (있다면 설명)

## 📝 추가 메모

<!-- 기타 참고사항 -->



---

## ✅ PR 체크리스트

- [ ] 코드 스타일 가이드 준수
- [ ] Self Review 완료
- [ ] 테스트 코드 작성 및 통과
- [ ] 문서 업데이트 (필요 시)
- [ ] 커밋 메시지 컨벤션 준수
- [ ] 충돌(Conflict) 해결 완료
