### PR TITLE
[FEAT] 활동후기 생성/조회/수정 api 구현

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,82 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Build
+./gradlew build
+./gradlew build -x test          # skip tests
+./gradlew lambdaJar              # build Lambda-specific JAR
+
+# Test
+./gradlew clean test --no-daemon --info --stacktrace
+./gradlew test --tests "sopt.org.homepage.ClassName"          # single class
+./gradlew test --tests "sopt.org.homepage.ClassName.method"   # single method
+
+# Local infrastructure
+docker-compose up -d             # starts PostgreSQL for local dev
+```
+
+Tests require Docker (TestContainers spins up a PostgreSQL container).
+
+## Architecture
+
+**Spring Boot 3.2.3, Java 17.** All API routes are prefixed with `/v2` (servlet context path).
+
+### Package layout (`sopt.org.homepage`)
+
+| Package | Role |
+|---|---|
+| `application/` | Use-case controllers and orchestration services (admin, homepage, recruitpage, visitor) |
+| `{domain}/` | Domain modules — notification, member, recruitment, review, soptstory, faq, news, etc. |
+| `infrastructure/` | External concerns: AWS S3, Caffeine/Redis cache, OpenFeign clients |
+| `global/` | Config beans, JWT filter chain, global exception handler, shared utilities |
+
+### Two module styles
+
+**Light modules** (most domains: notification, faq, news, member, part, generation, etc.)
+- Flat structure: entity → repository → service → controller
+- JPA entity acts as domain model — no separate domain object
+- Integration tests only (no unit tests), using `IntegrationTestBase`
+
+**Full DDD modules** (review, soptstory)
+- Rich domain models with business logic separated from entities
+- Unit-testable domain layer; integration tests for the full stack
+
+### Key infrastructure
+
+- **Database**: PostgreSQL. Flyway migrations under `classpath:db/migration`. Dev/prod use `ddl-auto: none` with Flyway enabled; test profile uses `ddl-auto: create-drop` with Flyway disabled.
+- **QueryDSL**: used for complex projections and read queries (Command/Query repository split on complex modules).
+- **Caching**: Caffeine by default; Redis available (Lambda profile). Switchable via `CacheType` enum.
+- **External HTTP**: OpenFeign clients in `infrastructure/external/` — Playground API, Crew API, Auth service.
+- **AWS**: S3 (presigned URL generation), Lambda (via `LambdaHandler` bridging API Gateway → Spring).
+- **Security**: JWT validated by `JwtAuthenticationFilter` + `JwtExceptionFilter`.
+
+### Environment / profiles
+
+Profiles: `dev`, `prod`, `lambda-dev`, `test`. Activate via `SPRING_PROFILES_ACTIVE`.
+
+Required environment variables (see `application-{profile}.yml` for full list):
+- `DB_HOST/PORT/DATABASE/USERNAME/PASSWORD`
+- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `BUCKET_NAME`
+- `JWT_*`, `ADMIN_TOKEN_SECRET`
+- `*_API_URL` for Playground, Crew, Auth clients
+- `REDIS_HOST`, `REDIS_PORT` (Lambda profile only)
+- `SENTRY_*_DSN`
+
+Dev defaults live in `src/main/resources/.env`.
+
+## Testing conventions
+
+- Base class: `IntegrationTestBase` — provides `@Transactional` rollback per test.
+- DisplayName emoji convention: `✅` success path, `❌` failure path, `🔍` query behavior.
+- Light modules → integration tests only. Full DDD modules → unit tests for domain + integration tests for the slice.
+- See `docs/testing-guide.md` for detailed patterns.
+
+## Deployment
+
+CI runs on PRs (`.github/workflows/ci.pr.yml`): YAML lint → tests → build → docker build.  
+CD on merge to `develop`/`main`: docker build → push to AWS ECR → deploy to EC2.  
+Lambda path: `deploy-lambda-dev.yml` packages with `lambdaJar` and deploys to AWS Lambda.

--- a/src/main/java/sopt/org/homepage/application/admin/dto/request/main/review/EditAdminReviewRequestDto.java
+++ b/src/main/java/sopt/org/homepage/application/admin/dto/request/main/review/EditAdminReviewRequestDto.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class AddAdminReviewRequestDto {
+public class EditAdminReviewRequestDto {
 
     @Schema(description = "리뷰 제목 (공백 포함 최대 10자)", example = "후회없는 활동")
     @NotBlank

--- a/src/main/java/sopt/org/homepage/application/admin/dto/response/main/review/AddAdminReviewResponseRecordDto.java
+++ b/src/main/java/sopt/org/homepage/application/admin/dto/response/main/review/AddAdminReviewResponseRecordDto.java
@@ -1,0 +1,14 @@
+package sopt.org.homepage.application.admin.dto.response.main.review;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "홈페이지 리뷰 추가")
+@Builder
+public record AddAdminReviewResponseRecordDto(
+        @Schema(description = "성공 메시지", requiredMode = Schema.RequiredMode.REQUIRED) String message
+) {
+    public static AddAdminReviewResponseRecordDto success() {
+        return new AddAdminReviewResponseRecordDto("홈페이지 리뷰 추가 성공");
+    }
+}

--- a/src/main/java/sopt/org/homepage/application/admin/dto/response/main/review/EditAdminReviewResponseRecordDto.java
+++ b/src/main/java/sopt/org/homepage/application/admin/dto/response/main/review/EditAdminReviewResponseRecordDto.java
@@ -1,0 +1,14 @@
+package sopt.org.homepage.application.admin.dto.response.main.review;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "홈페이지 리뷰 수정")
+@Builder
+public record EditAdminReviewResponseRecordDto(
+        @Schema(description = "성공 메시지", requiredMode = Schema.RequiredMode.REQUIRED) String message
+) {
+    public static EditAdminReviewResponseRecordDto success() {
+        return new EditAdminReviewResponseRecordDto("홈페이지 리뷰 수정 성공");
+    }
+}

--- a/src/main/java/sopt/org/homepage/application/admin/dto/response/main/review/GetAdminReviewResponseRecordDto.java
+++ b/src/main/java/sopt/org/homepage/application/admin/dto/response/main/review/GetAdminReviewResponseRecordDto.java
@@ -2,6 +2,7 @@ package sopt.org.homepage.application.admin.dto.response.main.review;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
+import sopt.org.homepage.application.homepage.review.domain.HomepageReview;
 
 @Schema(description = "리뷰")
 @Builder
@@ -11,4 +12,12 @@ public record GetAdminReviewResponseRecordDto(
         @Schema(description = "리뷰 내용", requiredMode = Schema.RequiredMode.REQUIRED) String content,
         @Schema(description = "작성자 정보", requiredMode = Schema.RequiredMode.REQUIRED) String authorInfo
 ) {
+    public static GetAdminReviewResponseRecordDto from(HomepageReview review) {
+        return new GetAdminReviewResponseRecordDto(
+                review.getId(),
+                review.getTitle(),
+                review.getContent(),
+                review.getAuthorInfo()
+        );
+    }
 }

--- a/src/main/java/sopt/org/homepage/application/homepage/review/controller/HomepageReviewController.java
+++ b/src/main/java/sopt/org/homepage/application/homepage/review/controller/HomepageReviewController.java
@@ -1,0 +1,61 @@
+package sopt.org.homepage.application.homepage.review.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sopt.org.homepage.application.admin.dto.request.main.review.AddAdminReviewRequestDto;
+import sopt.org.homepage.application.admin.dto.request.main.review.EditAdminReviewRequestDto;
+import sopt.org.homepage.application.admin.dto.response.main.review.AddAdminReviewResponseRecordDto;
+import sopt.org.homepage.application.admin.dto.response.main.review.EditAdminReviewResponseRecordDto;
+import sopt.org.homepage.application.admin.dto.response.main.review.GetAdminReviewResponseRecordDto;
+import sopt.org.homepage.application.homepage.review.service.HomepageReviewService;
+import sopt.org.homepage.global.common.constants.SecurityConstants;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("admin/homepage-reviews")
+@Tag(name = "Admin - HomepageReview", description = "홈페이지 리뷰 관리 API")
+public class HomepageReviewController {
+
+    private final HomepageReviewService homepageReviewService;
+
+    @Operation(summary = "홈페이지 리뷰 추가", description = "제목 최대 10자, 내용 최대 200자")
+    @SecurityRequirement(name = SecurityConstants.SCHEME_NAME)
+    @PostMapping
+    public ResponseEntity<AddAdminReviewResponseRecordDto> createReview(
+            @RequestBody @Valid AddAdminReviewRequestDto request
+    ) {
+        AddAdminReviewResponseRecordDto result = homepageReviewService.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
+    }
+
+    @Operation(summary = "홈페이지 리뷰 목록 조회", description = "ID 오름차순으로 전체 목록을 반환합니다")
+    @GetMapping
+    public ResponseEntity<List<GetAdminReviewResponseRecordDto>> getReviews() {
+        List<GetAdminReviewResponseRecordDto> result = homepageReviewService.getReviews();
+        return ResponseEntity.status(HttpStatus.OK).body(result);
+    }
+
+    @Operation(summary = "홈페이지 리뷰 수정", description = "제목 최대 10자, 내용 최대 200자")
+    @SecurityRequirement(name = SecurityConstants.SCHEME_NAME)
+    @PatchMapping("/{id}")
+    public ResponseEntity<EditAdminReviewResponseRecordDto> editReview(
+            @PathVariable Long id,
+            @RequestBody @Valid EditAdminReviewRequestDto request
+    ) {
+        EditAdminReviewResponseRecordDto result = homepageReviewService.edit(id, request);
+        return ResponseEntity.status(HttpStatus.OK).body(result);
+    }
+}

--- a/src/main/java/sopt/org/homepage/application/homepage/review/domain/HomepageReview.java
+++ b/src/main/java/sopt/org/homepage/application/homepage/review/domain/HomepageReview.java
@@ -44,4 +44,10 @@ public class HomepageReview {
     @UpdateTimestamp
     @Column(name = "\"updatedAt\"", nullable = false)
     private LocalDateTime updatedAt;
+
+    public void update(String title, String content, String authorInfo) {
+        this.title = title;
+        this.content = content;
+        this.authorInfo = authorInfo;
+    }
 }

--- a/src/main/java/sopt/org/homepage/application/homepage/review/repository/HomepageReviewRepository.java
+++ b/src/main/java/sopt/org/homepage/application/homepage/review/repository/HomepageReviewRepository.java
@@ -1,7 +1,10 @@
 package sopt.org.homepage.application.homepage.review.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import sopt.org.homepage.application.homepage.review.domain.HomepageReview;
 
 public interface HomepageReviewRepository extends JpaRepository<HomepageReview, Long> {
+
+    List<HomepageReview> findAllByOrderByIdAsc();
 }

--- a/src/main/java/sopt/org/homepage/application/homepage/review/service/HomepageReviewService.java
+++ b/src/main/java/sopt/org/homepage/application/homepage/review/service/HomepageReviewService.java
@@ -5,11 +5,15 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import sopt.org.homepage.application.admin.dto.request.main.review.AddAdminReviewRequestDto;
+import sopt.org.homepage.application.admin.dto.request.main.review.EditAdminReviewRequestDto;
+import sopt.org.homepage.application.admin.dto.response.main.review.AddAdminReviewResponseRecordDto;
+import sopt.org.homepage.application.admin.dto.response.main.review.EditAdminReviewResponseRecordDto;
+import sopt.org.homepage.application.admin.dto.response.main.review.GetAdminReviewResponseRecordDto;
 import sopt.org.homepage.application.homepage.review.domain.HomepageReview;
 import sopt.org.homepage.application.homepage.review.dto.BulkCreateHomepageReviewsCommand;
 import sopt.org.homepage.application.homepage.review.repository.HomepageReviewRepository;
-
-
+import sopt.org.homepage.global.exception.ClientBadRequestException;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -23,14 +27,36 @@ public class HomepageReviewService {
         return homepageReviewRepository.findAll();
     }
 
+    @Transactional(readOnly = true)
+    public List<GetAdminReviewResponseRecordDto> getReviews() {
+        return homepageReviewRepository.findAllByOrderByIdAsc().stream()
+                .map(GetAdminReviewResponseRecordDto::from)
+                .toList();
+    }
+
+    @Transactional
+    public AddAdminReviewResponseRecordDto create(AddAdminReviewRequestDto request) {
+        HomepageReview review = HomepageReview.create(request.getTitle(), request.getContent(), request.getAuthorInfo());
+        homepageReviewRepository.save(review);
+        log.info("HomepageReview 생성 완료 - id={}", review.getId());
+        return AddAdminReviewResponseRecordDto.success();
+    }
+
+    @Transactional
+    public EditAdminReviewResponseRecordDto edit(Long id, EditAdminReviewRequestDto request) {
+        HomepageReview review = homepageReviewRepository.findById(id)
+                .orElseThrow(() -> new ClientBadRequestException("HomepageReview not found with id: " + id));
+        review.update(request.getTitle(), request.getContent(), request.getAuthorInfo());
+        log.info("HomepageReview 수정 완료 - id={}", id);
+        return EditAdminReviewResponseRecordDto.success();
+    }
+
     @Transactional
     public void bulkCreate(BulkCreateHomepageReviewsCommand command) {
         List<HomepageReview> reviews = command.reviews().stream()
                 .map(r -> HomepageReview.create(r.title(), r.content(), r.authorInfo()))
                 .toList();
-
         homepageReviewRepository.saveAll(reviews);
-
         log.info("HomepageReview 일괄 생성 완료 - count={}", reviews.size());
     }
 }

--- a/src/test/java/sopt/org/homepage/homepagereview/HomepageReviewServiceTest.java
+++ b/src/test/java/sopt/org/homepage/homepagereview/HomepageReviewServiceTest.java
@@ -1,0 +1,131 @@
+package sopt.org.homepage.homepagereview;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import sopt.org.homepage.application.admin.dto.request.main.review.AddAdminReviewRequestDto;
+import sopt.org.homepage.application.admin.dto.request.main.review.EditAdminReviewRequestDto;
+import sopt.org.homepage.application.admin.dto.response.main.review.AddAdminReviewResponseRecordDto;
+import sopt.org.homepage.application.admin.dto.response.main.review.EditAdminReviewResponseRecordDto;
+import sopt.org.homepage.application.admin.dto.response.main.review.GetAdminReviewResponseRecordDto;
+import sopt.org.homepage.application.homepage.review.domain.HomepageReview;
+import sopt.org.homepage.application.homepage.review.repository.HomepageReviewRepository;
+import sopt.org.homepage.application.homepage.review.service.HomepageReviewService;
+import sopt.org.homepage.common.IntegrationTestBase;
+import sopt.org.homepage.global.exception.ClientBadRequestException;
+
+@DisplayName("HomepageReview 서비스 통합 테스트")
+class HomepageReviewServiceTest extends IntegrationTestBase {
+
+    @Autowired
+    private HomepageReviewService homepageReviewService;
+
+    @Autowired
+    private HomepageReviewRepository homepageReviewRepository;
+
+    @AfterEach
+    void tearDown() {
+        homepageReviewRepository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("홈페이지 리뷰 생성")
+    class Create {
+
+        @Test
+        @DisplayName("✅ 정상: 리뷰 생성")
+        void create_Success() {
+            AddAdminReviewRequestDto request = new AddAdminReviewRequestDto(
+                    "후회없는활동", "정말 좋은 활동이었습니다", "김솝트 | 36기 | 서버"
+            );
+
+            AddAdminReviewResponseRecordDto result = homepageReviewService.create(request);
+
+            assertThat(result.message()).isEqualTo("홈페이지 리뷰 추가 성공");
+            assertThat(homepageReviewRepository.findAll()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("✅ 정상: 제목 공백 포함 10자")
+        void create_TitleWithSpaces_Success() {
+            AddAdminReviewRequestDto request = new AddAdminReviewRequestDto(
+                    "후회 없는 활", "내용입니다", "김솝트 | 36기 | 서버"
+            );
+
+            homepageReviewService.create(request);
+
+            assertThat(homepageReviewRepository.findAll().get(0).getTitle()).isEqualTo("후회 없는 활");
+        }
+    }
+
+    @Nested
+    @DisplayName("홈페이지 리뷰 목록 조회")
+    class GetList {
+
+        @Test
+        @DisplayName("🔍 조회: ID 오름차순 정렬")
+        void getReviews_OrderById_Success() {
+            homepageReviewRepository.saveAll(List.of(
+                    HomepageReview.create("리뷰1", "내용1", "작성자1"),
+                    HomepageReview.create("리뷰2", "내용2", "작성자2"),
+                    HomepageReview.create("리뷰3", "내용3", "작성자3")
+            ));
+
+            List<GetAdminReviewResponseRecordDto> result = homepageReviewService.getReviews();
+
+            assertThat(result).hasSize(3);
+            assertThat(result.get(0).title()).isEqualTo("리뷰1");
+            assertThat(result.get(1).title()).isEqualTo("리뷰2");
+            assertThat(result.get(2).title()).isEqualTo("리뷰3");
+        }
+
+        @Test
+        @DisplayName("🔍 조회: 빈 목록")
+        void getReviews_Empty() {
+            List<GetAdminReviewResponseRecordDto> result = homepageReviewService.getReviews();
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("홈페이지 리뷰 수정")
+    class Edit {
+
+        @Test
+        @DisplayName("✅ 정상: 리뷰 수정")
+        void edit_Success() {
+            HomepageReview saved = homepageReviewRepository.save(
+                    HomepageReview.create("원본제목", "원본내용", "원본작성자")
+            );
+            EditAdminReviewRequestDto request = new EditAdminReviewRequestDto(
+                    "수정제목", "수정된 내용입니다", "수정작성자 | 37기"
+            );
+
+            EditAdminReviewResponseRecordDto result = homepageReviewService.edit(saved.getId(), request);
+
+            assertThat(result.message()).isEqualTo("홈페이지 리뷰 수정 성공");
+            HomepageReview updated = homepageReviewRepository.findById(saved.getId()).orElseThrow();
+            assertThat(updated.getTitle()).isEqualTo("수정제목");
+            assertThat(updated.getContent()).isEqualTo("수정된 내용입니다");
+        }
+
+        @Test
+        @DisplayName("❌ 실패: 존재하지 않는 리뷰 수정")
+        void edit_NotFound_ThrowsException() {
+            EditAdminReviewRequestDto request = new EditAdminReviewRequestDto(
+                    "수정제목", "수정내용", "작성자"
+            );
+
+            assertThatThrownBy(() -> homepageReviewService.edit(999L, request))
+                    .isInstanceOf(ClientBadRequestException.class)
+                    .hasMessageContaining("not found");
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 이 PR이 해결하는 이슈 -->
Related to #261

## 📋 작업 내용 요약

<!-- 이 PR에서 무엇을 했나요? -->

### 주요 변경사항
- 활동 후기 생성/조회/수정 api를 구현했습니다.

-
-

## 💡 구현 방법

<!-- 어떻게 구현했나요? 기술적 선택의 이유는? -->

## 📸 스크린샷 / 실행 결과

<!-- UI 변경이나 실행 결과가 있다면 -->

## 🧪 테스트

<!-- 어떤 테스트를 했나요? -->

### 테스트 케이스

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 추가/수정
- [ ] 수동 테스트 완료

### 테스트 시나리오

1.
2.
3.

## 🔍 리뷰 포인트

<!-- 리뷰어가 특히 봐줬으면 하는 부분 -->
- 

-

## ⚠️ 주의사항

<!-- 배포 시 주의할 점이나 Breaking Changes -->

- [ ] Breaking Change 없음
- [ ] DB 마이그레이션 필요 (있다면 설명)
- [ ] 환경 변수 추가/변경 (있다면 설명)
- [ ] 의존성 추가/변경 (있다면 설명)

## 📝 추가 메모

<!-- 기타 참고사항 -->



---

## ✅ PR 체크리스트

- [ ] 코드 스타일 가이드 준수
- [ ] Self Review 완료
- [ ] 테스트 코드 작성 및 통과
- [ ] 문서 업데이트 (필요 시)
- [ ] 커밋 메시지 컨벤션 준수
- [ ] 충돌(Conflict) 해결 완료
