### PR TITLE
[FIX] AcitivitySchedule INSERT 시 순서 충돌 오류 해결

### DIFF
--- a/src/main/java/sopt/org/homepage/activityschedule/ActivityScheduleRepository.java
+++ b/src/main/java/sopt/org/homepage/activityschedule/ActivityScheduleRepository.java
@@ -2,10 +2,15 @@ package sopt.org.homepage.activityschedule;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ActivityScheduleRepository extends JpaRepository<ActivitySchedule, Long> {
 
     List<ActivitySchedule> findByGenerationIdOrderByStartDateAsc(Integer generationId);
 
-    void deleteByGenerationId(Integer generationId);
+    @Modifying
+    @Query("DELETE FROM ActivitySchedule a WHERE a.generationId = :generationId")
+    void deleteByGenerationId(@Param("generationId") Integer generationId);
 }

--- a/src/main/resources/db/migration/V8__fix_activity_schedule_sequence.sql
+++ b/src/main/resources/db/migration/V8__fix_activity_schedule_sequence.sql
@@ -1,0 +1,5 @@
+SELECT setval(
+    pg_get_serial_sequence('"ActivitySchedule"', 'id'),
+    COALESCE((SELECT MAX("id") FROM "ActivitySchedule"), 0) + 1,
+    false
+);


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 이 PR이 해결하는 이슈 -->
Related to #273

## 📋 작업 내용 요약

<!-- 이 PR에서 무엇을 했나요? -->

### 주요 변경사항
- 기존 delete(`void deleteByGenerationId(...)`)는 Spring Data JPA가 내부적으로 SELECT → 엔티티 개별 remove() 순으로 동작합니다. 이 삭제는 persistence context에 큐잉될 뿐, 즉시 DB에 SQL을 보내지 않습니다. 반면 GenerationType.IDENTITY 전략을 쓰는 saveAll은 INSERT마다 즉시 SQL을 실행합니다. 결과적으로 DELETE보다 INSERT가 먼저 DB에 도달할 수 있고, 시퀀스가 기존 레코드와 충돌하는 ID를 돌려줄 경우 duplicate key 에러가 발생합니다. `@Modifying @Query`로 교체하면 즉시 bulk DELETE SQL이 실행되어 INSERT보다 항상 먼저 DB에 반영됩니다.
-  ActivitySchedule 테이블에 수동 SQL 등으로 명시적 ID를 지정해 삽입된 데이터가 있으면 PostgreSQL 시퀀스가 실제 최대 ID보다 낮은 값을 가리킵니다. 이 상태에서 새 레코드를 insert하면 시퀀스가 이미 존재하는 ID를 돌려줘 duplicate key 에러가 납니다. 이 마이그레이션은 시퀀스를 MAX(id) + 1로 한 번 교정해 현재 DB 상태의 불일치를 해소합니다.


## 💡 구현 방법

<!-- 어떻게 구현했나요? 기술적 선택의 이유는? -->

## 📸 스크린샷 / 실행 결과

<!-- UI 변경이나 실행 결과가 있다면 -->

## 🧪 테스트

<!-- 어떤 테스트를 했나요? -->

### 테스트 케이스

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 추가/수정
- [ ] 수동 테스트 완료

### 테스트 시나리오

1.
2.
3.

## 🔍 리뷰 포인트

<!-- 리뷰어가 특히 봐줬으면 하는 부분 -->
- 

-

## ⚠️ 주의사항

<!-- 배포 시 주의할 점이나 Breaking Changes -->

- [ ] Breaking Change 없음
- [ ] DB 마이그레이션 필요 (있다면 설명)
- [ ] 환경 변수 추가/변경 (있다면 설명)
- [ ] 의존성 추가/변경 (있다면 설명)

## 📝 추가 메모

<!-- 기타 참고사항 -->



---

## ✅ PR 체크리스트

- [ ] 코드 스타일 가이드 준수
- [ ] Self Review 완료
- [ ] 테스트 코드 작성 및 통과
- [ ] 문서 업데이트 (필요 시)
- [ ] 커밋 메시지 컨벤션 준수
- [ ] 충돌(Conflict) 해결 완료
